### PR TITLE
fix: ensure review outputs are blank if not populated

### DIFF
--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -72,8 +72,6 @@ runs:
       run : |
         # Populate defaults
         echo "classic=false" >> "$GITHUB_OUTPUT"
-        echo "slots=''" >> "$GITHUB_OUTPUT"
-        echo "plugs=''" >> "$GITHUB_OUTPUT"
 
         # Check for classic confinement and update the output if the snap is classic
         if [[ "$(cat snap/snapcraft.yaml | yq -r '.confinement')" == "classic" ]]; then

--- a/test-snap-build/action.yaml
+++ b/test-snap-build/action.yaml
@@ -27,8 +27,6 @@ runs:
       run : |
         # Populate defaults
         echo "classic=false" >> "$GITHUB_OUTPUT"
-        echo "slots=''" >> "$GITHUB_OUTPUT"
-        echo "plugs=''" >> "$GITHUB_OUTPUT"
 
         # Check for classic confinement and update the output if the snap is classic
         if [[ "$(cat snap/snapcraft.yaml | yq -r '.confinement')" == "classic" ]]; then


### PR DESCRIPTION
Found the first bug :man_facepalming: 

This ensures we just leave the output empty if no plugs/slots are decalred.