### PR TITLE
fix: get classic input from 'parse' step in release job

### DIFF
--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -98,7 +98,9 @@ runs:
       uses: diddlesnaps/snapcraft-review-action@v1
       with:
         snap: ${{ steps.build.outputs.snap }}
-        isClassic: ${{ steps.build.outputs.classic }}
+        isClassic: ${{ steps.parse.outputs.classic }}
+        plugs: ${{ steps.parse.outputs.plugs }}
+        slots: ${{ steps.parse.outputs.slots }}
 
     - name: Release the built snap to latest/${{ inputs.channel }}
       id: publish


### PR DESCRIPTION
There was a slight typo in the release workflow which meant that the `classic` argument wasn't being passed correctly to the `review-tools` action.

Symptom is seen [here](https://github.com/jnsgruk/terraform/actions/runs/7085496875/job/19282764871#step:2:296). 

Drive-by to pass the plugs/slots declarations in where appropriate too, which I missed on the last pass.