### PR TITLE
feat: add snapcraft-yaml-path options to other workflows

### DIFF
--- a/call-for-testing/README.md
+++ b/call-for-testing/README.md
@@ -60,13 +60,14 @@ jobs:
 
 ### Inputs
 
-| Key             | Description                                                                                                                                                                             | Required | Default           |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :---------------- |
-| `architectures` | The architectures that the snap supports.                                                                                                                                               |    Y     |                   |
-| `ci-repo`       | The repo to fetch tools/templates from. Only for debugging.                                                                                                                             |    N     | `snapcrafters/ci` |
-| `channel`       | The channel to create the call for testing for.                                                                                                                                         |    N     | `candidate`       |
-| `github-token`  | A token with permissions to create issues on the repository.                                                                                                                            |    Y     |                   |
-| `store-token`   | A token with permissions to query the specified channel in the Snap Store. Only required if the revisions to test are not passed to the workflow by the `release-to-candidate` workflow |    N     |                   |
+| Key                   | Description                                                                                                                                                                             | Required | Default           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :---------------- |
+| `architectures`       | The architectures that the snap supports.                                                                                                                                               |    Y     |                   |
+| `ci-repo`             | The repo to fetch tools/templates from. Only for debugging.                                                                                                                             |    N     | `snapcrafters/ci` |
+| `channel`             | The channel to create the call for testing for.                                                                                                                                         |    N     | `candidate`       |
+| `github-token`        | A token with permissions to create issues on the repository.                                                                                                                            |    Y     |                   |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file.                                                                                                                                                  |    N     |
+| `store-token`         | A token with permissions to query the specified channel in the Snap Store. Only required if the revisions to test are not passed to the workflow by the `release-to-candidate` workflow |    N     |                   |
 
 ### Outputs
 

--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -53,7 +53,7 @@ runs:
       id: yaml-path
       shell: bash
       run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
           yaml_path="${{ inputs.snapcraft-yaml-path }}"
         else
           snapcraft_yaml_paths=(

--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -20,6 +20,9 @@ inputs:
   github-token:
     description: "A token with permissions to create issues on the repository"
     required: true
+  snapcraft-yaml-path:
+    description: "Custom path to snapcraft.yaml for when it is not in the default location."
+    required: false
   store-token:
     description: "A token with permissions to upload to the specified channel"
     required: false
@@ -45,13 +48,41 @@ runs:
       shell: bash
       run: |
         sudo snap install snapcraft --classic
+    
+    - name: Find the snapcraft.yaml path
+      id: yaml-path
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+          yaml_path="${{ inputs.snapcraft-yaml-path }}"
+        else
+          snapcraft_yaml_paths=(
+            "snap/snapcraft.yaml"
+            "snapcraft.yaml"
+            "build-aux/snap/snapcraft.yaml"
+            ".snapcraft.yaml"
+          )
+          
+          for file in "${snapcraft_yaml_paths[@]}"; do
+              if [[ -f "$file" ]]; then
+                  yaml_path="$file"
+              fi
+          done
+        fi
+        if [[ ! -n "${yaml-path}" ]]; then
+           echo "No snapcraft.yaml found" >2
+           exit 1
+        fi
+        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
 
     - name: Write the arch/rev table
       shell: bash
       id: build
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
-        SNAP_NAME: ${{ github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snapcraft_yaml: ${{ steps.yaml-path.outputs.yaml-path }}
       run: |
         revisions=()
 
@@ -76,7 +107,7 @@ runs:
           
           # Otherwise, get the latest revision for each architecture in the release channel
           for arch in ${{ inputs.architectures }}; do
-            rev="$(snapcraft list-revisions "${SNAP_NAME}" --arch "$arch" | grep "latest/${{ inputs.channel }}*" | head -n1 | cut -d' ' -f1)"
+            rev="$(snapcraft list-revisions "${snap_name}" --arch "$arch" | grep "latest/${{ inputs.channel }}*" | head -n1 | cut -d' ' -f1)"
             revisions+=("$rev")
             # Add a row to the HTML table
             table="${table}<tr><td>${arch}</td><td>${rev}</td></tr>"
@@ -89,7 +120,7 @@ runs:
         # Get a comma separated list of revisions
         printf -v joined '%s,' "${revisions[@]}"
 
-        version="$(cat snap/snapcraft.yaml | yq -r '.version')"
+        version="$(cat "$snapcraft_yaml" | yq -r '.version')"
         echo "version=${version}" >> "$GITHUB_OUTPUT"
         echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
         echo "table=${table}" >> "$GITHUB_OUTPUT"
@@ -104,7 +135,7 @@ runs:
       id: issue
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        snap_name: ${{ github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
         channel: ${{ inputs.channel }}
         revisions: ${{ steps.build.outputs.revisions }}
         table: ${{ steps.build.outputs.table }}

--- a/get-architectures/README.md
+++ b/get-architectures/README.md
@@ -24,7 +24,9 @@ jobs:
 
 ### Inputs
 
-None
+| Key                   | Description                            | Required | Default |
+| --------------------- | -------------------------------------- | :------: | :------ |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file. |    N     |         |
 
 ### Outputs
 

--- a/get-architectures/action.yaml
+++ b/get-architectures/action.yaml
@@ -5,6 +5,11 @@ branding:
   icon: code
   color: orange
 
+inputs:
+  snapcraft-yaml-path:
+    description: "Custom path to snapcraft.yaml for when it is not in the default location."
+    required: false
+
 outputs:
   architectures:
     description: "A space-separated list of architectures supported by the snap"
@@ -19,20 +24,49 @@ runs:
     - name: Checkout the source
       uses: actions/checkout@v4
 
+    - name: Find the snapcraft.yaml path
+      id: yaml-path
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+          yaml_path="${{ inputs.snapcraft-yaml-path }}"
+        else
+          snapcraft_yaml_paths=(
+            "snap/snapcraft.yaml"
+            "snapcraft.yaml"
+            "build-aux/snap/snapcraft.yaml"
+            ".snapcraft.yaml"
+          )
+          
+          for file in "${snapcraft_yaml_paths[@]}"; do
+              if [[ -f "$file" ]]; then
+                  yaml_path="$file"
+              fi
+          done
+        fi
+        if [[ ! -n "${yaml-path}" ]]; then
+           echo "No snapcraft.yaml found" >2
+           exit 1
+        fi
+        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+
     - name: Compute architectures
       id: architectures
       shell: bash
+      env:
+        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
       run: |
         # Get the list as a json array. E.g. ["amd64", "arm64"]
-        architectures_list="$(cat snap/snapcraft.yaml | yq -r -I=0 -o=json '[.architectures[]]')"
+        architectures_list="$(cat "$yaml_path" | yq -r -I=0 -o=json '[.architectures[]]')"
         
         # Get the list as a space-separated string. E.g. "amd64" "arm64"
-        architectures="$(cat snap/snapcraft.yaml | yq -r -I=0 -o=csv '[.architectures[]]' | tr ',' ' ')"
+        architectures="$(cat "$yaml_path" | yq -r -I=0 -o=csv '[.architectures[]]' | tr ',' ' ')"
 
         # Handle the case where architectures is a list of objects
         if echo "$architectures" | grep -q "build-on"; then
-            architectures_list="$(cat snap/snapcraft.yaml | yq -r -I=0 -o=json '[.architectures[]."build-on"]')"
-            architectures="$(cat snap/snapcraft.yaml | yq -r -I=0 -o=csv '[.architectures[]."build-on"]' | tr ',' ' ')"
+            architectures_list="$(cat "$yaml_path" | yq -r -I=0 -o=json '[.architectures[]."build-on"]')"
+            architectures="$(cat "$yaml_path" | yq -r -I=0 -o=csv '[.architectures[]."build-on"]' | tr ',' ' ')"
         fi
 
         echo "architectures_list=$architectures_list" >> "$GITHUB_OUTPUT"

--- a/get-screenshots/README.md
+++ b/get-screenshots/README.md
@@ -27,14 +27,15 @@ jobs:
 
 ### Inputs
 
-| Key                 | Description                                                                                                        | Required | Default                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ | :------: | :---------------------------- |
-| `issue-number`      | The issue number to post the screenshots to.                                                                       |    Y     |                               |
-| `ci-repo`           | The repo to fetch tools/templates from. Only for debugging.                                                        |    N     | `snapcrafters/ci`             |
-| `channel`           | The channel to create the call for testing for.                                                                    |    N     | `candidate`                   |
-| `github-token`      | A token with permissions to common on issues in the repository.                                                    |    Y     |                               |
-| `screenshots-repo`  | The repository where screenshots should be uploaded.                                                               |    N     | `snapcrafters/ci-screenshots` |
-| `screenshots-token` | A token with permissions to commit screenshots to [ci-screenshots](https://github.com/snapcrafters/ci-screenshots) |    Y     |                               |
+| Key                   | Description                                                                                                        | Required | Default                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | :------: | :---------------------------- |
+| `issue-number`        | The issue number to post the screenshots to.                                                                       |    Y     |                               |
+| `ci-repo`             | The repo to fetch tools/templates from. Only for debugging.                                                        |    N     | `snapcrafters/ci`             |
+| `channel`             | The channel to create the call for testing for.                                                                    |    N     | `candidate`                   |
+| `github-token`        | A token with permissions to common on issues in the repository.                                                    |    Y     |                               |
+| `screenshots-repo`    | The repository where screenshots should be uploaded.                                                               |    N     | `snapcrafters/ci-screenshots` |
+| `screenshots-token`   | A token with permissions to commit screenshots to [ci-screenshots](https://github.com/snapcrafters/ci-screenshots) |    Y     |                               |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file.                                                                             |    N     |
 
 ### Outputs
 

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -58,7 +58,7 @@ runs:
       id: yaml-path
       shell: bash
       run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
           yaml_path="${{ inputs.snapcraft-yaml-path }}"
         else
           snapcraft_yaml_paths=(

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -20,6 +20,9 @@ inputs:
   github-token:
     description: "A token with permissions to comment on issues"
     required: true
+  snapcraft-yaml-path:
+    description: "Custom path to snapcraft.yaml for when it is not in the default location."
+    required: false
   screenshots-repo:
     description: "The repository where screenshots should be uploaded."
     default: "snapcrafters/ci-screenshots"
@@ -50,11 +53,38 @@ runs:
       uses: actions/download-artifact@v3
       with:
         name: manifests
+    
+    - name: Find the snapcraft.yaml path
+      id: yaml-path
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+          yaml_path="${{ inputs.snapcraft-yaml-path }}"
+        else
+          snapcraft_yaml_paths=(
+            "snap/snapcraft.yaml"
+            "snapcraft.yaml"
+            "build-aux/snap/snapcraft.yaml"
+            ".snapcraft.yaml"
+          )
+          
+          for file in "${snapcraft_yaml_paths[@]}"; do
+              if [[ -f "$file" ]]; then
+                  yaml_path="$file"
+              fi
+          done
+        fi
+        if [[ ! -n "${yaml-path}" ]]; then
+           echo "No snapcraft.yaml found" >2
+           exit 1
+        fi
+        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
 
     - name: Prepare VM
       shell: bash
       env:
-        SNAP_NAME: ${{ github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       run: |
         ghvmctl prepare
 
@@ -62,13 +92,13 @@ runs:
         if ls manifest-amd64.yaml &>/dev/null; then
           rev="$(cat manifest-amd64.yaml | yq -r '.revision')"
           echo "Installing snap revision '${rev}' from build manifest"
-          ghvmctl install-snap "${SNAP_NAME}" --revision "${rev}"
+          ghvmctl install-snap "${snap_name}" --revision "${rev}"
         else
           echo "Installing snap from 'latest/${{ inputs.channel}}'"
-          ghvmctl install-snap "${SNAP_NAME}" --channel "latest/${{ inputs.channel }}"
+          ghvmctl install-snap "${snap_name}" --channel "latest/${{ inputs.channel }}"
         fi
 
-        ghvmctl run-snap "${SNAP_NAME}"
+        ghvmctl run-snap "${snap_name}"
         sleep 60
 
     - name: Gather screenshots
@@ -80,9 +110,9 @@ runs:
     - name: Output application logs
       shell: bash
       env:
-        SNAP_NAME: ${{ github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       run: |
-        ghvmctl exec "cat /home/ubuntu/${SNAP_NAME}.log"
+        ghvmctl exec "cat /home/ubuntu/${snap_name}.log"
 
     - name: Checkout screenshots repo
       uses: actions/checkout@v4
@@ -95,9 +125,9 @@ runs:
       shell: bash
       id: screenshots
       env:
-        SNAP_NAME: ${{ github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       run: |
-        file_prefix="$(date +%Y%m%d)-${SNAP_NAME}-${{ inputs.issue-number }}"
+        file_prefix="$(date +%Y%m%d)-${snap_name}-${{ inputs.issue-number }}"
 
         pushd ci-screenshots
         mv "$HOME/ghvmctl-screenshots/screenshot-screen.png" "${file_prefix}-screen.png"
@@ -107,7 +137,7 @@ runs:
         git config --global user.name "Snapcrafters Bot"
 
         git add -A .
-        git commit -m "data: screenshots for snapcrafters/${SNAP_NAME}#${{ inputs.issue-number }}"
+        git commit -m "data: screenshots for snapcrafters/${snap_name}#${{ inputs.issue-number }}"
         git push origin main
 
         echo "screen=https://raw.githubusercontent.com/${{ inputs.screenshots-repo }}/main/${file_prefix}-screen.png" >> "$GITHUB_OUTPUT"

--- a/promote-to-stable/README.md
+++ b/promote-to-stable/README.md
@@ -27,11 +27,12 @@ jobs:
 
 ### Inputs
 
-| Key            | Description                                                                              | Required | Default |
-| -------------- | ---------------------------------------------------------------------------------------- | :------: | :------ |
-| `github-token` | A token with permissions to write issues on the repository                               |    Y     |         |
-| `store-token`  | A token with permissions to upload and release to the `stable` channel in the Snap Store |    Y     |         |
-| `snap-name`    | The name of the snap to promote                                                          |    N     |         |
+| Key                   | Description                                                                              | Required | Default |
+| --------------------- | ---------------------------------------------------------------------------------------- | :------: | :------ |
+| `github-token`        | A token with permissions to write issues on the repository                               |    Y     |         |
+| `store-token`         | A token with permissions to upload and release to the `stable` channel in the Snap Store |    Y     |         |
+| `snap-name`           | The name of the snap to promote                                                          |    N     |         |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file.                                                   |    N     |
 
 ### Outputs
 

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -9,12 +9,12 @@ inputs:
   github-token:
     description: "A token with permissions to write issues on the repository"
     required: true
+  snapcraft-yaml-path:
+    description: "Custom path to snapcraft.yaml for when it is not in the default location."
+    required: false
   store-token:
     description: "A token with permissions to upload to the specified channel"
     required: true
-  snap-name:
-    description: "The name of the snap to promote"
-    required: false
 
 runs:
   using: composite
@@ -34,12 +34,39 @@ runs:
       shell: bash
       run: |
         sudo snap install --classic snapcraft
+    
+    - name: Find the snapcraft.yaml path
+      id: yaml-path
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+          yaml_path="${{ inputs.snapcraft-yaml-path }}"
+        else
+          snapcraft_yaml_paths=(
+            "snap/snapcraft.yaml"
+            "snapcraft.yaml"
+            "build-aux/snap/snapcraft.yaml"
+            ".snapcraft.yaml"
+          )
+          
+          for file in "${snapcraft_yaml_paths[@]}"; do
+              if [[ -f "$file" ]]; then
+                  yaml_path="$file"
+              fi
+          done
+        fi
+        if [[ ! -n "${yaml-path}" ]]; then
+           echo "No snapcraft.yaml found" >2
+           exit 1
+        fi
+        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
 
     - name: Promote snap to latest/stable
       id: promote
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
-        SNAP_NAME: ${{ inputs.snap-name || github.event.repository.name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       shell: bash
       run: |
         echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
@@ -70,7 +97,7 @@ runs:
         released_revs=()
 
         for r in $revs; do
-          snapcraft release $SNAP_NAME "$r" "$channel"
+          snapcraft release $snap_name "$r" "$channel"
           released_revs+=("$r")
         done
 

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -39,7 +39,7 @@ runs:
       id: yaml-path
       shell: bash
       run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
           yaml_path="${{ inputs.snapcraft-yaml-path }}"
         else
           snapcraft_yaml_paths=(

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -24,14 +24,13 @@ jobs:
 
 ### Inputs
 
-| Key               | Description                                                                               | Required | Default        |
-| ----------------- | ----------------------------------------------------------------------------------------- | :------: | :--------------|
-| `architecture`    | The architecture for which to build the snap.                                             |    N     | `amd64`        |
-| `channel`         | The channel to release the snap to.                                                       |    N     | `candidate`    |
-| `launchpad-token` | A token with permissions to create Launchpad remote builds.                               |    Y     |                |
-| `store-token`     | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                |
-| `snapcraft-yaml-path`       | The path to the Snapcraft YAML file.                                                                |    N     |    |
-
+| Key                   | Description                                                                               | Required | Default     |
+| --------------------- | ----------------------------------------------------------------------------------------- | :------: | :---------- |
+| `architecture`        | The architecture for which to build the snap.                                             |    N     | `amd64`     |
+| `channel`             | The channel to release the snap to.                                                       |    N     | `candidate` |
+| `launchpad-token`     | A token with permissions to create Launchpad remote builds.                               |    Y     |             |
+| `snapcraft-yaml-path` | The path to the Snapcraft YAML file.                                                      |    N     |             |
+| `store-token`         | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |             |
 
 ### Outputs
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -17,12 +17,12 @@ inputs:
   launchpad-token:
     description: "A token with permissions to create remote builds on Launchpad"
     required: true
-  store-token:
-    description: "A token with permissions to upload to the specified channel"
-    required: true
   snapcraft-yaml-path:
     description: "Custom path to snapcraft.yaml for when it is not in the default location."
     required: false
+  store-token:
+    description: "A token with permissions to upload to the specified channel"
+    required: true
 
 
 outputs:

--- a/sync-version/README.md
+++ b/sync-version/README.md
@@ -28,12 +28,11 @@ jobs:
 
 ### Inputs
 
-| Key             | Description                                                                                        | Required |
-| --------------- | -------------------------------------------------------------------------------------------------- | :------: |
-| `token`         | A token with permissions to commit to the repository.                                              |    Y     |
-| `update-script` | A script that checks for version updates and updates `snapcraft.yaml` and other files if required. |    Y     |
-| `snapcraft-yaml-path`     | The path to the `snapcraft.yaml` file.                                                             |    N     |
-
+| Key                   | Description                                                                                        | Required |
+| --------------------- | -------------------------------------------------------------------------------------------------- | :------: |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file.                                                             |    N     |
+| `token`               | A token with permissions to commit to the repository.                                              |    Y     |
+| `update-script`       | A script that checks for version updates and updates `snapcraft.yaml` and other files if required. |    Y     |
 
 ### Outputs
 

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -72,7 +72,7 @@ runs:
         prev_version: ${{ steps.yaml-path.outputs.prev-version }}
         snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       run: |
-        new_version="$(yq -r '.version' "$yaml-path")"
+        new_version="$(yq -r '.version' "$yaml_path")"
         if [[ ! "$prev_version" == "$new_version" ]]; then
             version=$new_version
         fi

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -70,7 +70,7 @@ runs:
       env:
         yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
         prev_version: ${{ steps.yaml-path.outputs.prev-version }}
-        SNAP_NAME: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
       run: |
         new_version="$(yq -r '.version' "$yaml-path")"
         if [[ ! "$prev_version" == "$new_version" ]]; then
@@ -79,8 +79,8 @@ runs:
         git config --global user.name 'Snapcrafters Bot'
         git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
         if [[ -n "${version:-}" ]]; then
-            git commit -am "chore: bump ${SNAP_NAME} to version $version"
+            git commit -am "chore: bump ${snap_name} to version $version"
         else
-            git commit -am "chore: bump ${SNAP_NAME} dependencies"
+            git commit -am "chore: bump ${snap_name} dependencies"
         fi
         git push

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -6,15 +6,15 @@ branding:
   color: orange
 
 inputs:
-  update-script:
-    description: "Bash script that fetches the latest version and updates the source tree as required."
-    required: true
-  token:
-    required: true
-    description: A token with write privileges to the repository.
   snapcraft-yaml-path:
     description: "Custom path to snapcraft.yaml for when it is not in the default location."
     required: false
+  token:
+    required: true
+    description: A token with write privileges to the repository.
+  update-script:
+    description: "Bash script that fetches the latest version and updates the source tree as required."
+    required: true
 
 runs:
   using: composite

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -28,7 +28,7 @@ runs:
       id: yaml-path
       shell: bash
       run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }} " ]]; then
+        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
           yaml_path="${{ inputs.snapcraft-yaml-path }}"
         else
           snapcraft_yaml_paths=(

--- a/test-snap-build/README.md
+++ b/test-snap-build/README.md
@@ -34,11 +34,10 @@ jobs:
 
 ### Inputs
 
-| Key       | Description                                                    | Required | Default |
-| --------- | -------------------------------------------------------------- | :------: | :------ |
-| `install` | If `true`, the built snap is install on the runner after build |    N     | `false` |
-| `snapcraft-yaml-path`| The path to the Snapcraft YAML file.                |    N     |         |
-
+| Key                   | Description                                                    | Required | Default |
+| --------------------- | -------------------------------------------------------------- | :------: | :------ |
+| `install`             | If `true`, the built snap is install on the runner after build |    N     | `false` |
+| `snapcraft-yaml-path` | The path to the Snapcraft YAML file.                           |    N     |         |
 
 ### Outputs
 


### PR DESCRIPTION
This PR adds the new `snapcraft-yaml-path` option to other workflows, and corrects a few small bugs in the previous implementation.