### PR TITLE
feat: add parse-snapcraft-yaml action

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ listed below has it's own README
 - [snapcrafters/ci/call-for-testing](call-for-testing/README.md)
 - [snapcrafters/ci/get-architectures](get-architectures/README.md)
 - [snapcrafters/ci/get-screenshots](get-screenshots/README.md)
+- [snapcrafters/ci/parse-snapcraft-yaml](parse-snapcraft-yaml/README.md)
 - [snapcrafters/ci/promote-to-stable](promote-to-stable/README.md)
 - [snapcrafters/ci/release-to-candidate](release-to-candidate/README.md)
 - [snapcrafters/ci/sync-version](sync-version/README.md)

--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -49,40 +49,19 @@ runs:
       run: |
         sudo snap install snapcraft --classic
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Write the arch/rev table
       shell: bash
       id: build
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
-        snapcraft_yaml: ${{ steps.yaml-path.outputs.yaml-path }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
+        snapcraft_yaml: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
       run: |
         revisions=()
 
@@ -121,8 +100,6 @@ runs:
         # Get a comma separated list of revisions
         printf -v joined '%s,' "${revisions[@]}"
 
-        version="$(yq -r '.version' "$snapcraft_yaml")"
-        echo "version=${version}" >> "$GITHUB_OUTPUT"
         echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
         echo "table=${table}" >> "$GITHUB_OUTPUT"
 
@@ -136,10 +113,10 @@ runs:
       id: issue
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         channel: ${{ inputs.channel }}
         revisions: ${{ steps.build.outputs.revisions }}
         table: ${{ steps.build.outputs.table }}
-        version: ${{ steps.build.outputs.version }}
+        version: ${{ steps.snapcraft-yaml.outputs.version }}
       with:
         filename: ./template.md

--- a/get-architectures/action.yaml
+++ b/get-architectures/action.yaml
@@ -24,38 +24,17 @@ runs:
     - name: Checkout the source
       uses: actions/checkout@v4
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Compute architectures
       id: architectures
       shell: bash
       env:
-        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
+        yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
       run: |
         # Get the list as a json array. E.g. ["amd64", "arm64"]
         architectures_list="$(yq -r -I=0 -o=json '[.architectures[]]' "$yaml_path")"

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -54,37 +54,16 @@ runs:
       with:
         name: manifests
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Prepare VM
       shell: bash
       env:
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
         ghvmctl prepare
 
@@ -110,7 +89,7 @@ runs:
     - name: Output application logs
       shell: bash
       env:
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
         ghvmctl exec "cat /home/ubuntu/${snap_name}.log"
 
@@ -125,7 +104,7 @@ runs:
       shell: bash
       id: screenshots
       env:
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
         file_prefix="$(date +%Y%m%d)-${snap_name}-${{ inputs.issue-number }}"
 

--- a/parse-snapcraft-yaml/README.md
+++ b/parse-snapcraft-yaml/README.md
@@ -1,0 +1,50 @@
+# snapcrafters/ci/parse-snapcraft-yaml
+
+This action is more for use internally than otherwise. It's purpose is to either find a snapcraft.yaml file from a list of known common locations in a repository, or take the path to a snapcraft.yaml, then parse some information from it and provide that information as outputs.
+
+You only need to specify the `snapcraft-yaml-path` input if your `snapcraft.yaml` is not in one of the following locations:
+
+- `.snapcraft.yaml`
+- `build-aux/snap/snapcraft.yaml`
+- `snap/snapcraft.yaml`
+- `snapcraft.yaml`
+
+The action will also try to locate files that can be used during the review phase to delcare plugs and slots. The default locations searched are:
+
+- `slot-declaration.json`
+- `.github/slot-declaration.json`
+- `plug-declaration.json`
+- `.github/plug-declaration.json`
+
+## Usage
+
+```yaml
+# ...
+jobs:
+  parse-snapcraft-yaml:
+    name: 🖥 Parse the snapcraft yaml file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+```
+
+## API
+
+### Inputs
+
+| Key                   | Description                            | Required | Default |
+| --------------------- | -------------------------------------- | :------: | :------ |
+| `snapcraft-yaml-path` | The path to the `snapcraft.yaml` file. |    N     |         |
+
+### Outputs
+
+| Key          | Description                                                                         | Example                    |
+| ------------ | ----------------------------------------------------------------------------------- | -------------------------- |
+| `classic`    | Whether to snap is strictly confined                                                | `false`                    |
+| `plugs-file` | The location of a plugs declaration file to be used during review, if one was found | `./plugs-declaration.json` |
+| `slots-file` | The location of a slots declaration file to be used during review, if one was found | `./slots-declaration.json` |
+| `snap_name`  | The name of the snap as declared in the snapcraft.yaml                              | `signal-desktop`           |
+| `version`    | The version declared in the snapcraft.yaml file                                     | `6.41.0`                   |
+| `yaml_path`  | The path to the snapcraft.yaml for the project                                      | `snap/snapcraft.yaml`      |

--- a/parse-snapcraft-yaml/action.yaml
+++ b/parse-snapcraft-yaml/action.yaml
@@ -1,0 +1,91 @@
+name: Parse Snapcraft YAML
+description: Finds the snapcraft yaml for a repo and parses key information from it.
+author: Snapcrafters
+branding:
+  icon: code
+  color: orange
+
+inputs:
+  snapcraft-yaml-path:
+    description: "Custom path to snapcraft.yaml for when it is not in the default location."
+    required: false
+
+outputs:
+  classic:
+    description: "Whether to snap is strictly confined"
+    value: ${{ steps.parse.outputs.classic }}
+  plugs-file:
+    description: "The location of a plugs declaration file to be used during review, if one was found"
+    value: ${{ steps.parse.outputs.plugs-file }}
+  slots-file:
+    description: "The location of a slots declaration file to be used during review, if one was found"
+    value: ${{ steps.parse.outputs.slots-file }}
+  snap-name:
+    description: "The name of the snap as declared in the snapcraft.yaml"
+    value: ${{ steps.parse.outputs.snap-name }}
+  version:
+    description: "The version declared in the snapcraft.yaml file"
+    value: ${{ steps.parse.outputs.version }}
+  yaml-path:
+    description: "The path to the snapcraft.yaml for the project"
+    value: ${{ steps.parse.outputs.yaml-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout the source
+      uses: actions/checkout@v4
+
+    - name: Find and parse snapcraft.yaml
+      id: parse
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
+          yaml_path="${{ inputs.snapcraft-yaml-path }}"
+        else
+          common_paths=(
+            ".snapcraft.yaml"
+            "build-aux/snap/snapcraft.yaml"
+            "snap/snapcraft.yaml"
+            "snapcraft.yaml"
+          )
+          
+          for file in "${common_paths[@]}"; do
+              if [[ -f "$file" ]]; then
+                  yaml_path="$file"
+              fi
+          done
+        fi
+
+        if [[ -z "${yaml_path}" ]]; then
+           echo "No snapcraft.yaml found"
+           exit 1
+        fi
+
+        # Populate defaults
+        echo "classic=false" >> "$GITHUB_OUTPUT"
+
+        # Check for classic confinement and update the output if the snap is classic
+        if [[ "$(yq -r '.confinement' "$yaml_path")" == "classic" ]]; then
+          echo "classic=true" >> "$GITHUB_OUTPUT"
+        fi
+
+        # Declare the common locations for plugs/slots declarations
+        plugs_files=("plug-declaration.json" ".github/plug-declaration.json")
+        slots_files=("slot-declaration.json" ".github/slot-declaration.json")
+
+        for file in "${plugs_files[@]}"; do
+          if [[ -f "$file" ]]; then
+            echo "plugs-file=$file" >> "$GITHUB_OUTPUT"
+          fi
+        done
+
+        for file in "${slots_files[@]}"; do
+          if [[ -f "$file" ]]; then
+            echo "slots-file=$file" >> "$GITHUB_OUTPUT"
+          fi
+        done
+
+        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+        echo "version=$(yq -r '.version' "$yaml_path")" >> "$GITHUB_OUTPUT"

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -19,6 +19,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout the source
+      uses: actions/checkout@v4
+
     - name: Parse slash command
       id: command
       uses: xt0rted/slash-command-action@v2
@@ -29,6 +32,20 @@ runs:
         reaction-type: "eyes"
         allow-edits: "false"
         permission-level: write
+
+    - name: Get valid revisions for promotion
+      id: valid-revisions
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        script: |
+          const issue = await github.rest.issues.get({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })
+
+          return issue.data.body.match(/\/promote ([0-9,]+)/)[1].split(",").join(" ")
 
     - name: Install snapcraft
       shell: bash
@@ -67,6 +84,7 @@ runs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
         snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        valid_revisions: ${{ steps.valid-revisions.outputs.result }}
       shell: bash
       run: |
         echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
@@ -96,16 +114,24 @@ runs:
         # Iterate over each specified revision and release
         revs=$(echo "$revision" | tr "," "\n")
         released_revs=()
+        rejected_revs=()
 
         for r in $revs; do
-          snapcraft release "$snap_name" "$r" "$channel"
-          released_revs+=("$r")
+          if [[ "$valid_revisions" =~ (^|[[:space:]])"$r"($|[[:space:]]) ]]; then
+            snapcraft release "$snap_name" "$r" "$channel"
+            released_revs+=("$r")
+          else
+            rejected_revs+=("$r")
+            echo "Not promoting revision '$r' because the revision is not related to this test."
+          fi
         done
 
         # Get a comma separated list of released revisions
         printf -v joined '%s,' "${released_revs[@]}"
+        printf -v joined_rejected '%s,' "${rejected_revs[@]}"
 
         echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
+        echo "rejected=${joined_rejected%,}" >> "$GITHUB_OUTPUT"
         echo "channel=$channel" >> "$GITHUB_OUTPUT"
         echo "done=$done" >> "$GITHUB_OUTPUT"
 
@@ -113,11 +139,20 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
+          let message = ""
+          if ("${{ steps.promote.outputs.revisions }}".length > 0) {
+            message += 'The following revisions were released to the `${{ steps.promote.outputs.channel }}` channel: `${{ steps.promote.outputs.revisions }}`. '
+          }
+
+          if ("${{ steps.promote.outputs.rejected }}".length > 0) {
+            message += 'The following revisions were not released, because they are unrelated to this call for testing: `${{ steps.promote.outputs.rejected }}`. '
+          }
+
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: 'The following revisions were released to the `${{ steps.promote.outputs.channel }}` channel: `${{ steps.promote.outputs.revisions }}`'
+            body: message
           })
 
     - name: Close call for testing issue
@@ -125,7 +160,7 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
-          if ("${{ steps.promote.outputs.done }}" === "done") {
+          if ("${{ steps.promote.outputs.done }}" === "done" && "${{ steps.promote.outputs.revisions }}".length > 0) {
             github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -52,38 +52,17 @@ runs:
       run: |
         sudo snap install --classic snapcraft
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Promote snap to latest/stable
       id: promote
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         valid_revisions: ${{ steps.valid-revisions.outputs.result }}
       shell: bash
       run: |

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -46,40 +46,20 @@ runs:
         git config --global user.email "github-actions@github.com"
         git config --global user.name "Github Actions"
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Build the snap (${{ inputs.architecture }})
       id: build
       shell: bash
       env:
-        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
-        name: ${{ steps.yaml-path.outputs.snap-name }}
         arch: ${{ inputs.architecture }}
+        name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
+        yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
+        version: ${{ steps.snapcraft-yaml.outputs.version }}
       run: |
         # Remove the architecture definition from the snapcraft.yaml due to:
         # https://bugs.launchpad.net/snapcraft/+bug/1885150
@@ -87,7 +67,6 @@ runs:
 
         snapcraft remote-build --launchpad-accept-public-upload --build-for="${arch}"
 
-        version="$(yq -r '.version' "$yaml_path")"
         if [[ ! -e "${name}_${version}_${arch}.snap" ]]; then
             echo "Could not find ${name}_${version}_${arch}.snap"
             cat "${name}_${arch}.txt"
@@ -95,49 +74,19 @@ runs:
         else
             cat "${name}_${arch}.txt"
         fi
-        echo "snap=${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
 
         # Write the manifest file which is used by later steps
+        echo "snap=${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
         echo "name: ${name}" >> "manifest-${arch}.yaml"
         echo "architecture: ${arch}" >> "manifest-${arch}.yaml"
-
-    - name: Parse snap review information
-      id: parse
-      shell: bash
-      env:
-        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
-      run: |
-        # Populate defaults
-        echo "classic=false" >> "$GITHUB_OUTPUT"
-
-        # Check for classic confinement and update the output if the snap is classic
-        if [[ "$(yq -r '.confinement' "$yaml_path")" == "classic" ]]; then
-          echo "classic=true" >> "$GITHUB_OUTPUT"
-        fi
-
-        # Declare the common locations for plugs/slots declarations
-        plugs_files=("plug-declaration.json" ".github/plug-declaration.json")
-        slots_files=("slot-declaration.json" ".github/slot-declaration.json")
-
-        for file in "${plugs_files[@]}"; do
-          if [[ -f "$file" ]]; then
-            echo "plugs=$file" >> "$GITHUB_OUTPUT"
-          fi
-        done
-
-        for file in "${slots_files[@]}"; do
-          if [[ -f "$file" ]]; then
-            echo "slots=$file" >> "$GITHUB_OUTPUT"
-          fi
-        done
 
     - name: Review the built snap
       uses: diddlesnaps/snapcraft-review-action@v1
       with:
         snap: ${{ steps.build.outputs.snap }}
-        isClassic: ${{ steps.parse.outputs.classic }}
-        plugs: ${{ steps.parse.outputs.plugs }}
-        slots: ${{ steps.parse.outputs.slots }}
+        isClassic: ${{ steps.snapcraft-yaml.outputs.classic }}
+        plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
+        slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
 
     - name: Release the built snap to latest/${{ inputs.channel }}
       id: publish

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -24,33 +24,11 @@ runs:
       with:
         token: ${{ inputs.token }}
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
-        echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
-        echo "prev-version=$(yq -r '.version' "$yaml_path")" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Run update script
       shell: bash
@@ -69,18 +47,18 @@ runs:
       if: steps.git-check.outputs.modified == 'true'
       shell: bash
       env:
-        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
-        prev_version: ${{ steps.yaml-path.outputs.prev-version }}
-        snap_name: ${{ steps.yaml-path.outputs.snap-name }}
+        snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
+        old_version: ${{ steps.snapcraft-yaml.outputs.version }}
+        yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
       run: |
         new_version="$(yq -r '.version' "$yaml_path")"
-        if [[ ! "$prev_version" == "$new_version" ]]; then
+        if [[ ! "$old_version" == "$new_version" ]]; then
             version=$new_version
         fi
         git config --global user.name 'Snapcrafters Bot'
         git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
         if [[ -n "${version:-}" ]]; then
-            git commit -am "chore: bump ${snap_name} to version $version"
+            git commit -am "chore: bump ${snap_name} to version ${version}"
         else
             git commit -am "chore: bump ${snap_name} dependencies"
         fi

--- a/test-snap-build/action.yaml
+++ b/test-snap-build/action.yaml
@@ -20,75 +20,25 @@ runs:
     - name: Checkout the source
       uses: actions/checkout@v4
 
-    - name: Find the snapcraft.yaml path
-      id: yaml-path
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.snapcraft-yaml-path }}" ]]; then
-          yaml_path="${{ inputs.snapcraft-yaml-path }}"
-        else
-          snapcraft_yaml_paths=(
-            "snap/snapcraft.yaml"
-            "snapcraft.yaml"
-            "build-aux/snap/snapcraft.yaml"
-            ".snapcraft.yaml"
-          )
-          
-          for file in "${snapcraft_yaml_paths[@]}"; do
-              if [[ -f "$file" ]]; then
-                  yaml_path="$file"
-              fi
-          done
-        fi
-        if [[ -z "${yaml_path}" ]]; then
-           echo "No snapcraft.yaml found"
-           exit 1
-        fi
-        echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
+    - name: Find and parse snapcraft.yaml
+      id: snapcraft-yaml
+      uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      with:
+        snapcraft-yaml-path: ${{ inputs.snapcraft-yaml-path }}
 
     - name: Build snap
       uses: snapcore/action-build@v1
       id: build
       with:
-        path: ${{ steps.yaml-path.outputs.yaml-path }}
-
-    - name: Parse snap review information
-      id: parse
-      shell: bash
-      env:
-        yaml_path: ${{ steps.yaml-path.outputs.yaml-path }}
-      run: |
-        # Populate defaults
-        echo "classic=false" >> "$GITHUB_OUTPUT"
-
-        # Check for classic confinement and update the output if the snap is classic
-        if [[ "$(yq -r '.confinement' "$yaml_path")" == "classic" ]]; then
-          echo "classic=true" >> "$GITHUB_OUTPUT"
-        fi
-
-        # Declare the common locations for plugs/slots declarations
-        plugs_files=("plug-declaration.json" ".github/plug-declaration.json")
-        slots_files=("slot-declaration.json" ".github/slot-declaration.json")
-
-        for file in "${plugs_files[@]}"; do
-          if [[ -f "$file" ]]; then
-            echo "plugs=$file" >> "$GITHUB_OUTPUT"
-          fi
-        done
-
-        for file in "${slots_files[@]}"; do
-          if [[ -f "$file" ]]; then
-            echo "slots=$file" >> "$GITHUB_OUTPUT"
-          fi
-        done
+        path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
 
     - name: Review the built snap
       uses: diddlesnaps/snapcraft-review-action@v1
       with:
         snap: ${{ steps.build.outputs.snap }}
-        isClassic: ${{ steps.parse.outputs.classic }}
-        plugs: ${{ steps.parse.outputs.plugs }}
-        slots: ${{ steps.parse.outputs.slots }}
+        isClassic: ${{ steps.snapcraft-yaml.outputs.classic }}
+        plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
+        slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
 
     - name: Install the snap
       if: ${{ inputs.install == 'true' }}


### PR DESCRIPTION
**Note**: This PR should only be reviewed once #16 is merged as this is based off that branch.

The duplication of code for finding and parsing the snapcraft.yaml was bothering me, so I've introduced a new action named `parse-snapcraft-yaml` which centralises that logic, and then adjusted the other workflows to use it, so this PR is a reduction in lines of code overall, even with the addition of a new README :slightly_smiling_face:. It also means we won't have multiple files to update each time we want to use a field from the `snapcraft.yaml` in a new way.