### PR TITLE
fix: don't checkout the source in parse-snapcraft-yaml action

### DIFF
--- a/parse-snapcraft-yaml/README.md
+++ b/parse-snapcraft-yaml/README.md
@@ -1,6 +1,6 @@
 # snapcrafters/ci/parse-snapcraft-yaml
 
-This action is more for use internally than otherwise. It's purpose is to either find a snapcraft.yaml file from a list of known common locations in a repository, or take the path to a snapcraft.yaml, then parse some information from it and provide that information as outputs.
+This action is more for use internally than otherwise. It's purpose is to either find a snapcraft.yaml file from a list of known common locations in a repository, or take the path to a snapcraft.yaml, then parse some information from it and provide that information as outputs. This action **will not** checkout the source code, and expects that to have already happened.
 
 You only need to specify the `snapcraft-project-root` input if your `snapcraft.yaml` is not in one of the following locations:
 

--- a/parse-snapcraft-yaml/action.yaml
+++ b/parse-snapcraft-yaml/action.yaml
@@ -36,9 +36,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout the source
-      uses: actions/checkout@v4
-
     - name: Find and parse snapcraft.yaml
       id: parse
       shell: bash


### PR DESCRIPTION
Don't checkout the source code in the internal action for parsing the snapcraft.yaml, because if it's already been checked out earlier then doing it again will clobber any credentials that have already been set up.