### PR TITLE
feat: create tags for new revisions published to the store

### DIFF
--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -29,6 +29,7 @@ jobs:
 | `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`     |
 | `channel`                | The channel to release the snap to.                                                       |    N     | `candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |             |
+| `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |             |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |             |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |             |
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -117,12 +117,14 @@ runs:
     # Create a tag in the repo that corresponds to the revision pushed
     - name: Create tag
       shell: bash
+      env:
+        version: ${{ steps.snapcraft-yaml.outputs.version }}
       run: |
         git config --global user.name 'Snapcrafters Bot'
         git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
 
         revision="${{ steps.publish.outputs.revision }}"
-        tag_name="rev${revision}/${{ inputs.architecture }}"
+        tag_name="${version}/rev${revision}/${{ inputs.architecture }}"
 
         git tag -a "$tag_name" -m "Revision ${revision}, released for ${{ inputs.architecture }}"
         git push origin "$tag_name"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -17,6 +17,9 @@ inputs:
   launchpad-token:
     description: "A token with permissions to create remote builds on Launchpad"
     required: true
+  repo-token:
+    required: true
+    description: A token with privileges to create and push tags to the repository.
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -34,6 +37,8 @@ runs:
   steps:
     - name: Checkout the source
       uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.repo-token }}
 
     - name: Setup snapcraft
       shell: bash
@@ -108,3 +113,16 @@ runs:
       with:
         name: "manifests"
         path: "manifest-${{ inputs.architecture }}.yaml"
+
+    # Create a tag in the repo that corresponds to the revision pushed
+    - name: Create tag
+      shell: bash
+      run: |
+        git config --global user.name 'Snapcrafters Bot'
+        git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
+
+        revision="${{ steps.publish.outputs.revision }}"
+        tag_name="rev${revision}/${{ inputs.architecture }}"
+
+        git tag -a "$tag_name" -m "Revision ${revision}, released for ${{ inputs.architecture }}"
+        git push origin "$tag_name"


### PR DESCRIPTION
Hey :wave: 

So as discussed in our catch-up meet, here is a first draft of how we might want to create tags automatically in repositories based on the revisions that were released to the store. The aim here is to make debugging issues a little easier, as when an issue is reported on a snap with a given revision, you can just checkout the tag and build/install/troubleshoot.

It's a little complicated with multiple architectures. The design I've chosen is to create one tag per revision, and name with the arch just to make searching/bisecting easier. The tag names will be `rev<num>/<arch>`.

You can see an example run [here](https://github.com/jnsgruk/ci-testing/actions/runs/7222177075) and the resulting tags [here](https://github.com/jnsgruk/ci-testing/tags).

I should note that this is actually a **breaking change** because all repos that use these workflows will need to add a new input to the release workflow. I think if we merge this, we should tag the repo at `v1`, and work on using the actions with a versioned reference like `@v1` rather than `@main`.

If this does merge, I'll do some follow-up PRs to address the incompatibilities on the other repos.