### PR TITLE
feat: use upload-artifacts@v4

### DIFF
--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -38,11 +38,10 @@ runs:
     - name: Checkout the source
       uses: actions/checkout@v4
 
-    - name: Download manifest files
-      continue-on-error: true
-      uses: actions/download-artifact@v3
+    - name: Fetch build manifests
+      uses: snapcrafters/ci/fetch-manifests@main
       with:
-        name: "manifests"
+        token: ${{ inputs.github-token }}
 
     - name: Setup snapcraft
       shell: bash

--- a/fetch-manifests/README.md
+++ b/fetch-manifests/README.md
@@ -1,0 +1,31 @@
+# snapcrafters/ci/fetch-manifests
+
+This action is more for use internally than otherwise. It's purpose is to download all and unpack
+all artifacts containing build manifests from the `snapcrafters/ci/release-to-candidate` workflow.
+
+## Usage
+
+```yaml
+# ...
+jobs:
+  fetch-manifests:
+    name: 📦 Fetch workflow manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch artifacts
+        uses: snapcrafters/ci/fetch-manifests@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## API
+
+### Inputs
+
+| Key     | Description                                                        | Required | Default |
+| ------- | ------------------------------------------------------------------ | :------: | :------ |
+| `token` | A token with permissions to download artifacts for the repository. |    Y     |         |
+
+### Outputs
+
+None

--- a/fetch-manifests/action.yaml
+++ b/fetch-manifests/action.yaml
@@ -1,0 +1,31 @@
+name: Fetch manifests
+description: Downloads and unzips all build manifest artifacts for the current workflow run.
+author: Snapcrafters
+branding:
+  icon: code
+  color: orange
+
+inputs:
+  token:
+    description: "A token with permissions to get artifacts from this repository"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch artifacts
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        # Construct the URL for the API endpoint where the artifacts are available
+        url="/repos/${{ github.repository }}/actions/runs/${GITHUB_RUN_ID}/artifacts"
+
+        # Get a list of IDs for appropriately named artifacts (those starting 'manifest-*')
+        artifacts="$(gh api "$url" --jq '.artifacts[] | select(.name | startswith("manifest-")) | .id')"
+
+        # Iterate over the manifest URLS, downloading and unpacking them one by one
+        for id in $artifacts; do
+          gh api "/repos/${{ github.repository }}/actions/artifacts/${id}/zip" > manifests.zip
+          unzip manifests.zip
+        done

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -48,11 +48,10 @@ runs:
     - name: Setup ghvmctl
       uses: snapcrafters/ci/setup-ghvmctl@main
 
-    - name: Download manifest files (if available)
-      continue-on-error: true
-      uses: actions/download-artifact@v3
+    - name: Fetch build manifests
+      uses: snapcrafters/ci/fetch-manifests@main
       with:
-        name: manifests
+        token: ${{ inputs.github-token }}
 
     - name: Find and parse snapcraft.yaml
       id: snapcraft-yaml

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -104,7 +104,7 @@ runs:
 
     # Upload the manifest file as an artifact for retrieval during future actions
     - name: Upload revision manifest
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4
       with:
-        name: "manifests"
+        name: "manifest-${{ inputs.architecture }}"
         path: "manifest-${{ inputs.architecture }}.yaml"

--- a/setup-ghvmctl/README.md
+++ b/setup-ghvmctl/README.md
@@ -31,7 +31,7 @@ jobs:
           ghvmctl exec "cat /home/ubuntu/signal-desktop.log"
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: "screenshots"
           path: "~/ghvmctl-screenshots/*.png"


### PR DESCRIPTION
There is a new release of the `upload-artifact` and `download-artifact` actions provided by Github that come with a [breaking change](https://github.com/actions/upload-artifact#breaking-changes) for us. We were previously relying on being able to have multiple jobs upload the same artifact name, and have Github automatically coalesce them.

This no longer works, but with the trade-off that artifacts are now available from the REST API immediately after the step that creates them completes.

The following implements the logic to fetch all of the artifacts from a given workflow run, and unzip them in place. This is actually how I had intended to do this before, but was hit by API limitations.

There is a demo workflow run [here](https://github.com/jnsgruk/ci-testing/actions/runs/7223794512) and the corresponding call for testing that was created [here](https://github.com/jnsgruk/ci-testing/issues/42).

This doesn't change the API, or expectations upon the repositories using the workflows in any way, and is just maintenance to keep the repo up to date and using the latest Github APIs :)