### PR TITLE
feat: enable `snapcraft-channel` to be passed to actions

### DIFF
--- a/call-for-testing/README.md
+++ b/call-for-testing/README.md
@@ -66,6 +66,7 @@ jobs:
 | `ci-repo`                | The repo to fetch tools/templates from. Only for debugging.                                                                                                                             |    N     | `snapcrafters/ci` |
 | `channel`                | The channel to create the call for testing for.                                                                                                                                         |    N     | `candidate`       |
 | `github-token`           | A token with permissions to create issues on the repository.                                                                                                                            |    Y     |                   |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                                                                                                                  |    N     | `latest/stable`   |
 | `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`.                                                       |    N     |
 | `store-token`            | A token with permissions to query the specified channel in the Snap Store. Only required if the revisions to test are not passed to the workflow by the `release-to-candidate` workflow |    N     |                   |
 

--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -23,6 +23,10 @@ inputs:
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
+  snapcraft-channel:
+    description: "The channel to install snapcraft from"
+    default: latest/stable
+    required: false
   store-token:
     description: "A token with permissions to upload to the specified channel"
     required: false
@@ -46,7 +50,7 @@ runs:
     - name: Setup snapcraft
       shell: bash
       run: |
-        sudo snap install snapcraft --classic
+        sudo snap install snapcraft --channel "${{inputs.snapcraft-channel}}" --classic
 
     - name: Find and parse snapcraft.yaml
       id: snapcraft-yaml

--- a/promote-to-stable/README.md
+++ b/promote-to-stable/README.md
@@ -27,11 +27,12 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                                                                       | Required | Default |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: | :------ |
-| `github-token`           | A token with permissions to write issues on the repository                                                                        |    Y     |         |
-| `store-token`            | A token with permissions to upload and release to the `stable` channel in the Snap Store                                          |    Y     |         |
-| `snap-name`              | The name of the snap to promote                                                                                                   |    N     |         |
+| Key                      | Description                                                                                                                       | Required | Default         |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: | :-------------- |
+| `github-token`           | A token with permissions to write issues on the repository                                                                        |    Y     |                 |
+| `store-token`            | A token with permissions to upload and release to the `stable` channel in the Snap Store                                          |    Y     |                 |
+| `snap-name`              | The name of the snap to promote                                                                                                   |    N     |                 |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                                                            |    N     | `latest/stable` |
 | `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. |    N     |
 
 ### Outputs

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -12,6 +12,10 @@ inputs:
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
+  snapcraft-channel:
+    description: "The channel to install snapcraft from"
+    default: latest/stable
+    required: false
   store-token:
     description: "A token with permissions to upload to the specified channel"
     required: true
@@ -50,7 +54,7 @@ runs:
     - name: Install snapcraft
       shell: bash
       run: |
-        sudo snap install --classic snapcraft
+        sudo snap install --classic --channel "${{inputs.snapcraft-channel}}" snapcraft
 
     - name: Find and parse snapcraft.yaml
       id: snapcraft-yaml

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -24,14 +24,15 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                               | Required | Default     |
-| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :---------- |
-| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`     |
-| `channel`                | The channel to release the snap to.                                                       |    N     | `candidate` |
-| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |             |
-| `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |             |
-| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |             |
-| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |             |
+| Key                      | Description                                                                               | Required | Default         |
+| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :-------------- |
+| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`         |
+| `channel`                | The channel to release the snap to.                                                       |    N     | `candidate`     |
+| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                 |
+| `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
+| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                 |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable` |
+| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                 |
 
 ### Outputs
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -23,6 +23,10 @@ inputs:
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
+  snapcraft-channel:
+    description: "The channel to install snapcraft from"
+    default: latest/stable
+    required: false
   store-token:
     description: "A token with permissions to upload to the specified channel"
     required: true
@@ -43,7 +47,7 @@ runs:
     - name: Setup snapcraft
       shell: bash
       run: |
-        sudo snap install snapcraft --classic
+        sudo snap install snapcraft --channel "${{inputs.snapcraft-channel}}" --classic
 
         # Setup Launchpad credentials
         mkdir -p ~/.local/share/snapcraft/provider/launchpad

--- a/test-snap-build/README.md
+++ b/test-snap-build/README.md
@@ -34,10 +34,11 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                    | Required | Default |
-| ------------------------ | -------------------------------------------------------------- | :------: | :------ |
-| `install`                | If `true`, the built snap is install on the runner after build |    N     | `false` |
-| `snapcraft-project-root` | The path to the Snapcraft YAML file.                           |    N     |         |
+| Key                      | Description                                                    | Required | Default         |
+| ------------------------ | -------------------------------------------------------------- | :------: | :-------------- |
+| `install`                | If `true`, the built snap is install on the runner after build |    N     | `false`         |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                         |    N     | `latest/stable` |
+| `snapcraft-project-root` | The path to the Snapcraft YAML file.                           |    N     |                 |
 
 ### Outputs
 

--- a/test-snap-build/action.yaml
+++ b/test-snap-build/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: "Option to install the snap on the runner after build"
     default: "false"
     required: false
+  snapcraft-channel:
+    description: "The channel to install snapcraft from"
+    default: latest/stable
+    required: false
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -31,6 +35,7 @@ runs:
       id: build
       with:
         path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+        snapcraft-channel: ${{ inputs.snapcraft-channel }}
 
     - name: Review the built snap
       uses: diddlesnaps/snapcraft-review-action@v1


### PR DESCRIPTION
Some snaps cannot be built with the `latest/stable` snapcraft, for example those that rely on `core18`.

This change enables developers to specify which channel they wish to use when installing snapcraft.