### PR TITLE
feat: enable building/promoting to tracks other than `latest`

### DIFF
--- a/call-for-testing/README.md
+++ b/call-for-testing/README.md
@@ -39,7 +39,7 @@ jobs:
 ### Use standalone - `store-token` required
 
 In this mode, the action will use the store token to fetch the latest revision on the specified
-channel (`candidate` by default) for each architecture and populate the call for testing with those
+channel (`latest/candidate` by default) for each architecture and populate the call for testing with those
 revisions.
 
 ```yaml
@@ -60,15 +60,16 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                                                                                                                             | Required | Default           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :---------------- |
-| `architectures`          | The architectures that the snap supports.                                                                                                                                               |    Y     |                   |
-| `ci-repo`                | The repo to fetch tools/templates from. Only for debugging.                                                                                                                             |    N     | `snapcrafters/ci` |
-| `channel`                | The channel to create the call for testing for.                                                                                                                                         |    N     | `candidate`       |
-| `github-token`           | A token with permissions to create issues on the repository.                                                                                                                            |    Y     |                   |
-| `snapcraft-channel`      | The channel to install Snapcraft from.                                                                                                                                                  |    N     | `latest/stable`   |
+| Key                      | Description                                                                                                                                                                             | Required | Default            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :----------------- |
+| `architectures`          | The architectures that the snap supports.                                                                                                                                               |    Y     |                    |
+| `ci-repo`                | The repo to fetch tools/templates from. Only for debugging.                                                                                                                             |    N     | `snapcrafters/ci`  |
+| `channel`                | The channel to create the call for testing for.                                                                                                                                         |    N     | `latest/candidate` |
+| `github-token`           | A token with permissions to create issues on the repository.                                                                                                                            |    Y     |                    |
+| `promotion-channel`      | The channel the snap should be promoted to on successful test.                                                                                                                          |    N     | `latest/stable`    |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                                                                                                                  |    N     | `latest/stable`    |
 | `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`.                                                       |    N     |
-| `store-token`            | A token with permissions to query the specified channel in the Snap Store. Only required if the revisions to test are not passed to the workflow by the `release-to-candidate` workflow |    N     |                   |
+| `store-token`            | A token with permissions to query the specified channel in the Snap Store. Only required if the revisions to test are not passed to the workflow by the `release-to-candidate` workflow |    N     |                    |
 
 ### Outputs
 

--- a/call-for-testing/action.yaml
+++ b/call-for-testing/action.yaml
@@ -15,11 +15,15 @@ inputs:
     required: false
   channel:
     description: "The channel to publish the snap to"
-    default: "candidate"
+    default: "latest/candidate"
     required: false
   github-token:
     description: "A token with permissions to create issues on the repository"
     required: true
+  promotion-channel:
+    description: "The channel the snap should be promoted to on successful test"
+    default: "latest/stable"
+    required: false
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -90,7 +94,7 @@ runs:
           # Otherwise, get the latest revision for each architecture in the release channel
           # shellcheck disable=SC1083
           for arch in ${{ inputs.architectures }}; do
-            rev="$(snapcraft list-revisions "${snap_name}" --arch "$arch" | grep "latest/${{ inputs.channel }}*" | head -n1 | cut -d' ' -f1)"
+            rev="$(snapcraft list-revisions "${snap_name}" --arch "$arch" | grep "${{ inputs.channel }}*" | head -n1 | cut -d' ' -f1)"
             revisions+=("$rev")
             # Add a row to the HTML table
             table="${table}<tr><td>${arch}</td><td>${rev}</td></tr>"
@@ -121,5 +125,6 @@ runs:
         revisions: ${{ steps.build.outputs.revisions }}
         table: ${{ steps.build.outputs.table }}
         version: ${{ steps.snapcraft-yaml.outputs.version }}
+        promotion_channel: ${{ inputs.promotion-channel }}
       with:
         filename: ./template.md

--- a/call-for-testing/template.md
+++ b/call-for-testing/template.md
@@ -29,16 +29,16 @@ The snap will be installed in a VM automatically; screenshots will be posted as 
 
 ## How to release it
 
-Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] stable [done]`.
+Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] ${{ env.promotion_channel }} [done]`.
 
 > For example
 >
-> - To promote a single revision, run `/promote <rev> stable`
-> - To promote multiple revisions, run `/promote <rev>,<rev> stable`
-> - To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
+> - To promote a single revision, run `/promote <rev> ${{ env.promotion_channel }}`
+> - To promote multiple revisions, run `/promote <rev>,<rev> ${{ env.promotion_channel }}`
+> - To promote a revision and close the issue, run `/promote <rev>,<rev> ${{ env.promotion_channel }} done`
 
 You can promote all revisions that were just built with:
 
 ```
-/promote {{ env.revisions }} stable done
+/promote {{ env.revisions }} ${{ env.promotion_channel }} done
 ```

--- a/get-screenshots/README.md
+++ b/get-screenshots/README.md
@@ -1,6 +1,6 @@
 # snapcrafters/ci/get-screenshots
 
-Deploys the snap from `latest/candidate` in a LXD desktop VM, then takes screenshots of the whole
+Deploys the snap from the specified channel in a LXD desktop VM, then takes screenshots of the whole
 desktop, and the most recent active window after the snap was launched. Screenshots are then
 committed to [ci-screenshots](https://github.com/snapcrafters/ci-screenshots), and added to a comment on
 the original call for testing issue.
@@ -31,7 +31,7 @@ jobs:
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: | :---------------------------- |
 | `issue-number`           | The issue number to post the screenshots to.                                                                                      |    Y     |                               |
 | `ci-repo`                | The repo to fetch tools/templates from. Only for debugging.                                                                       |    N     | `snapcrafters/ci`             |
-| `channel`                | The channel to create the call for testing for.                                                                                   |    N     | `candidate`                   |
+| `channel`                | The channel to create the call for testing for.                                                                                   |    N     | `latest/candidate`            |
 | `github-token`           | A token with permissions to common on issues in the repository.                                                                   |    Y     |                               |
 | `screenshots-repo`       | The repository where screenshots should be uploaded.                                                                              |    N     | `snapcrafters/ci-screenshots` |
 | `screenshots-token`      | A token with permissions to commit screenshots to [ci-screenshots](https://github.com/snapcrafters/ci-screenshots)                |    Y     |                               |

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -14,8 +14,8 @@ inputs:
     default: "snapcrafters/ci"
     required: false
   channel:
-    description: "The channel to publish the snap to"
-    default: "candidate"
+    description: "The channel to install the snap from"
+    default: "latest/candidate"
     required: false
   github-token:
     description: "A token with permissions to comment on issues"
@@ -72,8 +72,8 @@ runs:
           echo "Installing snap revision '${rev}' from build manifest"
           ghvmctl snap-install "${snap_name}" --revision "${rev}"
         else
-          echo "Installing snap from 'latest/${{ inputs.channel}}'"
-          ghvmctl snap-install "${snap_name}" --channel "latest/${{ inputs.channel }}"
+          echo "Installing snap from '${{ inputs.channel}}'"
+          ghvmctl snap-install "${snap_name}" --channel "${{ inputs.channel }}"
         fi
 
         ghvmctl snap-run "${snap_name}"

--- a/promote-to-stable/README.md
+++ b/promote-to-stable/README.md
@@ -2,7 +2,7 @@
 
 Promote to stable is generally triggered in response to a Snapcrafters reviewer posting a comment
 containing a `/promote` command. Once the arguments are successfully parsed, the specified
-revisions are promoted to `latest/stable`
+revisions are promoted to the specified channel (`latest/stable`) by default.
 
 ## Usage
 
@@ -29,8 +29,9 @@ jobs:
 
 | Key                      | Description                                                                                                                       | Required | Default         |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: | :-------------- |
+| `channel`                | The channel to promote the snap to.                                                                                               |    N     | `latest/stable` |
 | `github-token`           | A token with permissions to write issues on the repository                                                                        |    Y     |                 |
-| `store-token`            | A token with permissions to upload and release to the `stable` channel in the Snap Store                                          |    Y     |                 |
+| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store                                         |    Y     |                 |
 | `snap-name`              | The name of the snap to promote                                                                                                   |    N     |                 |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                                                            |    N     | `latest/stable` |
 | `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. |    N     |

--- a/promote-to-stable/action.yaml
+++ b/promote-to-stable/action.yaml
@@ -1,11 +1,15 @@
-name: Promote to latest/stable
-description: Promotes a given set of revisions from candidate -> stable
+name: Promote snap
+description: Promotes a given set of revisions to a specified channel
 author: Snapcrafters
 branding:
   icon: trending-up
   color: orange
 
 inputs:
+  channel:
+    description: "The channel to promote the snap to"
+    default: "latest/stable"
+    required: false
   github-token:
     description: "A token with permissions to write issues on the repository"
     required: true
@@ -62,9 +66,10 @@ runs:
       with:
         snapcraft-project-root: ${{ inputs.snapcraft-project-root }}
 
-    - name: Promote snap to latest/stable
+    - name: Promote snap
       id: promote
       env:
+        channel: ${{ inputs.channel }}
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
         snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         valid_revisions: ${{ steps.valid-revisions.outputs.result }}
@@ -75,7 +80,7 @@ runs:
         # shellcheck disable=SC1083,SC2206
         arguments=(${{ steps.command.outputs.command-arguments }})
         revision=${arguments[0]}
-        channel=${arguments[1]}
+        requested_channel=${arguments[1]}
         done=${arguments[2]}
 
         re='^[0-9]+([,][0-9]+)*$'
@@ -84,8 +89,8 @@ runs:
           exit 1
         fi
 
-        if [[ "$channel" != "stable"  ]]; then
-          echo "I can only promote to stable, not '$channel'!"
+        if [[ "$requested_channel" != "$channel" ]]; then
+          echo "I can only promote to ${channel}, not '$requested_channel'!"
           exit 1
         fi
 
@@ -101,7 +106,7 @@ runs:
 
         for r in $revs; do
           if [[ "$valid_revisions" =~ (^|[[:space:]])"$r"($|[[:space:]]) ]]; then
-            snapcraft release "$snap_name" "$r" "$channel"
+            snapcraft release "$snap_name" "$r" "$requested_channel"
             released_revs+=("$r")
           else
             rejected_revs+=("$r")
@@ -115,7 +120,7 @@ runs:
 
         echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
         echo "rejected=${joined_rejected%,}" >> "$GITHUB_OUTPUT"
-        echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        echo "channel=$requested_channel" >> "$GITHUB_OUTPUT"
         echo "done=$done" >> "$GITHUB_OUTPUT"
 
     - name: Comment on call for testing issue

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -1,7 +1,7 @@
 # snapcrafters/ci/release-to-candidate
 
 This action is used to run `snapcraft remote-build` for a given Snap, and a given architecture.
-Following that, the snap is released to the `latest/candidate` automatically.
+Following that, the snap is released to the specified channel automatically.
 
 ## Usage
 
@@ -24,15 +24,15 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                               | Required | Default         |
-| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :-------------- |
-| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`         |
-| `channel`                | The channel to release the snap to.                                                       |    N     | `candidate`     |
-| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                 |
+| Key                      | Description                                                                               | Required | Default            |
+| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :----------------- |
+| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`            |
+| `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
+| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                 |
-| `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable` |
-| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                 |
+| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
+| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |
 
 ### Outputs
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: false
   channel:
     description: "The channel to publish the snap to"
-    default: "candidate"
+    default: "latest/candidate"
     required: false
   launchpad-token:
     description: "A token with permissions to create remote builds on Launchpad"
@@ -99,7 +99,7 @@ runs:
         plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
         slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
 
-    - name: Release the built snap to latest/${{ inputs.channel }}
+    - name: Release the built snap to ${{ inputs.channel }}
       id: publish
       shell: bash
       env:

--- a/sync-version/README.md
+++ b/sync-version/README.md
@@ -28,11 +28,12 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                                                                       | Required |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: |
-| `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. |    N     |
-| `token`                  | A token with permissions to commit to the repository.                                                                             |    Y     |
-| `update-script`          | A script that checks for version updates and updates `snapcraft.yaml` and other files if required.                                |    Y     |
+| Key                      | Description                                                                                                                       | Required |   Default   |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | -------- | :---------: |
+| `branch`                 | The branch on which modifications to snapcraft.yaml should be made.                                                               | N        | `candidate` |
+| `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. | N        |             |
+| `token`                  | A token with permissions to commit to the repository.                                                                             | Y        |             |
+| `update-script`          | A script that checks for version updates and updates `snapcraft.yaml` and other files if required.                                | Y        |             |
 
 ### Outputs
 

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -6,6 +6,10 @@ branding:
   color: orange
 
 inputs:
+  branch:
+    description: "The branch on which modifications to snapcraft.yaml should be made."
+    default: "candidate"
+    required: false
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -23,6 +27,7 @@ runs:
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
+        ref: ${{ inputs.branch }}
 
     - name: Find and parse snapcraft.yaml
       id: snapcraft-yaml


### PR DESCRIPTION
This is a first stab at making these workflows more channel agnostic.

Until this point, only `latest/candidate` and `latest/stable` were considered. In this commit, we formalise that as `latest/candidate` as the default in all places, which should be backwards compatible. We also introduce `channel` as an input in more places and thread it through where necessary.

I *think* this is all that is needed to ensure that snaps such as `gimp` can run multiple tracks/channels.