### PR TITLE
fix: remove extraneous $ in templates

### DIFF
--- a/call-for-testing/template.md
+++ b/call-for-testing/template.md
@@ -29,16 +29,16 @@ The snap will be installed in a VM automatically; screenshots will be posted as 
 
 ## How to release it
 
-Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] ${{ env.promotion_channel }} [done]`.
+Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] {{ env.promotion_channel }} [done]`.
 
 > For example
 >
-> - To promote a single revision, run `/promote <rev> ${{ env.promotion_channel }}`
-> - To promote multiple revisions, run `/promote <rev>,<rev> ${{ env.promotion_channel }}`
-> - To promote a revision and close the issue, run `/promote <rev>,<rev> ${{ env.promotion_channel }} done`
+> - To promote a single revision, run `/promote <rev> {{ env.promotion_channel }}`
+> - To promote multiple revisions, run `/promote <rev>,<rev> {{ env.promotion_channel }}`
+> - To promote a revision and close the issue, run `/promote <rev>,<rev> {{ env.promotion_channel }} done`
 
 You can promote all revisions that were just built with:
 
 ```
-/promote {{ env.revisions }} ${{ env.promotion_channel }} done
+/promote {{ env.revisions }} {{ env.promotion_channel }} done
 ```

--- a/call-for-testing/template.md
+++ b/call-for-testing/template.md
@@ -17,7 +17,7 @@ The snap will be installed in a VM automatically; screenshots will be posted as 
 1. Upgrade to this version by running
 
    ```shell
-   snap refresh {{ env.snap_name }} --{{ env.channel }}
+   snap refresh {{ env.snap_name }} --channel {{ env.channel }}
    ```
 
 1. Start the app and test it out.


### PR DESCRIPTION
Just noticed this mistake in a new call for testing, `$` is not required here.