### PR TITLE
feat: expose `max-parallel-build-count` option on test-snap-build

### DIFF
--- a/test-snap-build/README.md
+++ b/test-snap-build/README.md
@@ -34,11 +34,12 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                    | Required | Default         |
-| ------------------------ | -------------------------------------------------------------- | :------: | :-------------- |
-| `install`                | If `true`, the built snap is install on the runner after build |    N     | `false`         |
-| `snapcraft-channel`      | The channel to install Snapcraft from.                         |    N     | `latest/stable` |
-| `snapcraft-project-root` | The path to the Snapcraft YAML file.                           |    N     |                 |
+| Key                                  | Description                                                           | Required | Default         |
+| ------------------------------------ | --------------------------------------------------------------------- | :------: | :-------------- |
+| `install`                            | If `true`, the built snap is install on the runner after build        |    N     | `false`         |
+| `snapcraft-channel`                  | The channel to install Snapcraft from.                                |    N     | `latest/stable` |
+| `snapcraft-max-parallel-build-count` | Controls the number of parallel builds in the snapcraft pack process. |    N     |                 |
+| `snapcraft-project-root`             | The path to the Snapcraft YAML file.                                  |    N     |                 |
 
 ### Outputs
 

--- a/test-snap-build/action.yaml
+++ b/test-snap-build/action.yaml
@@ -14,6 +14,9 @@ inputs:
     description: "The channel to install snapcraft from"
     default: latest/stable
     required: false
+  snapcraft-max-parallel-build-count:
+    description: "Controls the number of parallel builds in the snapcraft pack process."
+    required: false
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -36,6 +39,7 @@ runs:
       with:
         path: ${{ steps.snapcraft-yaml.outputs.project-root }}
         snapcraft-channel: ${{ inputs.snapcraft-channel }}
+        snapcraft-max-parallel-build-count: ${{ inputs.snacraft-max-parallel-build-count }}
 
     - name: Review the built snap
       uses: diddlesnaps/snapcraft-review-action@v1


### PR DESCRIPTION
Allows the developer to cap the number of parallel builds during the snap build to avoid starving the runners of resources.

Waiting on https://github.com/snapcore/action-build/pull/70