### PR TITLE
feat: allow specification of app inside snap to screenshot

### DIFF
--- a/get-screenshots/README.md
+++ b/get-screenshots/README.md
@@ -35,6 +35,7 @@ jobs:
 | `github-token`           | A token with permissions to common on issues in the repository.                                                                   |    Y     |                               |
 | `screenshots-repo`       | The repository where screenshots should be uploaded.                                                                              |    N     | `snapcrafters/ci-screenshots` |
 | `screenshots-token`      | A token with permissions to commit screenshots to [ci-screenshots](https://github.com/snapcrafters/ci-screenshots)                |    Y     |                               |
+| `snap-application-name`  | The name of the application defined in `snapcraft.yaml` to run for screenshots.                                                   |    N     |                               |
 | `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. |    N     |
 
 ### Outputs

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -20,6 +20,9 @@ inputs:
   github-token:
     description: "A token with permissions to comment on issues"
     required: true
+  snap-application-name:
+    description: "The name of the application defined in `snapcraft.yaml` to run for screenshots."
+    required: false
   snapcraft-project-root:
     description: "The root of the snapcraft project, where the `snapcraft` command would usually be executed from."
     required: false
@@ -63,6 +66,7 @@ runs:
       shell: bash
       env:
         snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
+        snap_app: ${{ inputs.snap-application-name }}
       run: |
         ghvmctl prepare
 
@@ -76,7 +80,12 @@ runs:
           ghvmctl snap-install "${snap_name}" --channel "${{ inputs.channel }}"
         fi
 
-        ghvmctl snap-run "${snap_name}"
+        # If the snap-application-name is empty, default to the name of the snap
+        if [[ -z "$snap_app" ]]; then
+          snap_app="$snap_name"
+        fi
+
+        ghvmctl snap-run "${snap_name}.${snap_app}"
         sleep 60
 
     - name: Gather screenshots


### PR DESCRIPTION
Allows the specification of an application name to execute inside the snap when taking screenshots.

Helps when the snap has a different "app name" to "snap name". E.g. the `sublime-text` snap only has an app named `subl` defined, which led to this failure in CI: https://github.com/snapcrafters/sublime-text/actions/runs/7844422700/job/21407033718#step:2:292