### PR TITLE
fix: update architectures in snapcraft yaml rather than remove

### DIFF
--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -71,12 +71,12 @@ runs:
         version: ${{ steps.snapcraft-yaml.outputs.version }}
         project_root: ${{ steps.snapcraft-yaml.outputs.project-root }}
       run: |
-        # Remove the architecture definition from the snapcraft.yaml due to:
+        # Restrict arch definition to one only in snapcraft.yaml due to:
         # https://bugs.launchpad.net/snapcraft/+bug/1885150
-        yq -i 'del(.architectures)' "$yaml_path"
+        yq -i '.architectures |= [{"build-on": env(arch)}]' "$yaml_path"
 
-        cd "$project_root" || exit 
-        if ! snapcraft remote-build --launchpad-accept-public-upload --build-for="${arch}"; then
+        cd "$project_root" || exit
+        if ! snapcraft remote-build --launchpad-accept-public-upload; then
           cat "${name}_${arch}.txt"
         fi
 


### PR DESCRIPTION
Ensure that we update the archs, rather than remove - such that each build gets a new hash and we don't get collisions in Launchpad's backend.