### PR TITLE
feat: new remote-builder backend and misc improvement

### DIFF
--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -30,7 +30,7 @@ jobs:
 | `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'false'`          |
+| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'true'`          |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -30,7 +30,6 @@ jobs:
 | `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'true'`           |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -30,7 +30,7 @@ jobs:
 | `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `show-build-log`         | Show the build log even if the build succeed |  N  | `'false'` |
+| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'false'`          |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -30,7 +30,7 @@ jobs:
 | `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'true'`          |
+| `show-build-log`         | Show the build log even if the build succeed                                              |    N     | `'true'`           |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -30,6 +30,7 @@ jobs:
 | `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
 | `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
+| `show-build-log`         | Show the build log even if the build succeed |  N  | `'false'` |
 | `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
 | `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
 | `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -6,10 +6,6 @@ branding:
   color: orange
 
 inputs:
-  show-build-log:
-    description: "Show the build log even if the build succeed"
-    default: "true"
-    required: false
   architecture:
     description: "The architecture to build the snap for"
     default: amd64
@@ -86,10 +82,7 @@ runs:
           cat "${name}_${arch}.txt"
         fi
 
-        # Check if build log is requested
-        if [[ "$show_build_log" == "true" ]]; then
-            cat "${name}_${arch}.txt"
-        fi
+        cat "${name}_${arch}.txt"
 
         if [[ ! -e "${name}_${version}_${arch}.snap" ]]; then
             echo "Could not find ${name}_${version}_${arch}.snap"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -88,7 +88,10 @@ runs:
         fi
 
         # Write the manifest file which is used by later steps
-        echo "snap=${project_root}/${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+        echo "snap=${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+        if  [[ -n "$project_root" ]]; then
+            echo "snap=${project_root}/${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+        fi
         echo "name: ${name}" >> "manifest-${arch}.yaml"
         echo "architecture: ${arch}" >> "manifest-${arch}.yaml"
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -88,7 +88,7 @@ runs:
         fi
 
         # Write the manifest file which is used by later steps
-        echo "snap=${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+        echo "snap=${project_root}/${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
         echo "name: ${name}" >> "manifest-${arch}.yaml"
         echo "architecture: ${arch}" >> "manifest-${arch}.yaml"
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -69,6 +69,7 @@ runs:
       id: build
       shell: bash
       env:
+        SNAPCRAFT_REMOTE_BUILD_STRATEGY: "disable-fallback" 
         show_build_log: ${{ inputs.show-build-log }}
         arch: ${{ inputs.architecture }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
@@ -80,7 +81,7 @@ runs:
         # https://bugs.launchpad.net/snapcraft/+bug/1885150
         yq -i '.architectures |= [{"build-on": env(arch)}]' "$yaml_path"
 
-        cd "$project_root" || exit
+        cd "$project_root" && git init || exit
         if ! snapcraft remote-build --launchpad-accept-public-upload; then
           cat "${name}_${arch}.txt"
         fi

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -66,7 +66,6 @@ runs:
       shell: bash
       env:
         SNAPCRAFT_REMOTE_BUILD_STRATEGY: "disable-fallback"
-        show_build_log: ${{ inputs.show-build-log }}
         arch: ${{ inputs.architecture }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -6,6 +6,10 @@ branding:
   color: orange
 
 inputs:
+  show-build-log:
+    description: "Show the build log even if the build succeed"
+    default: 'false'
+    required: false
   architecture:
     description: "The architecture to build the snap for"
     default: amd64
@@ -65,6 +69,7 @@ runs:
       id: build
       shell: bash
       env:
+        show_build_log: ${{ inputs.show-build-log }}
         arch: ${{ inputs.architecture }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
@@ -80,7 +85,10 @@ runs:
           cat "${name}_${arch}.txt"
         fi
 
-        cat "${name}_${arch}.txt"
+        # Check if build log is requested
+        if [[ "$show_build_log" -eq "true" ]]; then
+            cat "${name}_${arch}.txt"
+        fi
 
         if [[ ! -e "${name}_${version}_${arch}.snap" ]]; then
             echo "Could not find ${name}_${version}_${arch}.snap"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -8,7 +8,7 @@ branding:
 inputs:
   show-build-log:
     description: "Show the build log even if the build succeed"
-    default: "false"
+    default: "true"
     required: false
   architecture:
     description: "The architecture to build the snap for"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -86,7 +86,7 @@ runs:
         fi
 
         # Check if build log is requested
-        if [[ "$show_build_log" -eq "true" ]]; then
+        if [[ "$show_build_log" == "true" ]]; then
             cat "${name}_${arch}.txt"
         fi
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -8,7 +8,7 @@ branding:
 inputs:
   show-build-log:
     description: "Show the build log even if the build succeed"
-    default: 'false'
+    default: "false"
     required: false
   architecture:
     description: "The architecture to build the snap for"
@@ -69,7 +69,7 @@ runs:
       id: build
       shell: bash
       env:
-        SNAPCRAFT_REMOTE_BUILD_STRATEGY: "disable-fallback" 
+        SNAPCRAFT_REMOTE_BUILD_STRATEGY: "disable-fallback"
         show_build_log: ${{ inputs.show-build-log }}
         arch: ${{ inputs.architecture }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}


### PR DESCRIPTION
1. This PR now adds support to use the new backend of snapcraft remote-build. The build seems significantly better. Also allows the `lint` and other keywords on the toplevel that were `core22` only.
2. Fixes the `project_root`  not being used while reviewing the snap file
3. adds a new input named `show-build-log` which is `true` by default and shows the build log on success if true.