### PR TITLE
feat: Add support for building + releasing core24 based snaps

### DIFF
--- a/get-architectures/action.yaml
+++ b/get-architectures/action.yaml
@@ -36,16 +36,22 @@ runs:
       env:
         yaml_path: ${{ steps.snapcraft-yaml.outputs.yaml-path }}
       run: |
-        # Get the list as a json array. E.g. ["amd64", "arm64"]
-        architectures_list="$(yq -r -I=0 -o=json '[.architectures[]]' "$yaml_path")"
-
-        # Get the list as a space-separated string. E.g. "amd64" "arm64"
-        architectures="$(yq -r -I=0 -o=csv '[.architectures[]]' "$yaml_path" | tr ',' ' ')"
-
-        # Handle the case where architectures is a list of objects
-        if echo "$architectures" | grep -q "build-on"; then
+        # core24 uses a different syntax for specifying platforms.
+        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]]; then
+          architectures_list="$(yq -r -I=0 -o=json '[.platforms | to_entries | .[] | .key]' "$yaml_path")"
+          architectures="$(yq -r -I=0 -o=csv '[.platforms | to_entries | .[] | .key]' "$yaml_path" | tr ',' ' ')"
+        else
+          # Get the list as a json array. E.g. ["amd64", "arm64"]
+          architectures_list="$(yq -r -I=0 -o=json '[.architectures[]]' "$yaml_path")"
+          
+          # Get the list as a space-separated string. E.g. "amd64" "arm64"
+          architectures="$(yq -r -I=0 -o=csv '[.architectures[]]' "$yaml_path" | tr ',' ' ')"
+          
+          # Handle the case where architectures is a list of objects
+          if echo "$architectures" | grep -q "build-on"; then
             architectures_list="$(yq -r -I=0 -o=json '[.architectures[]."build-on"]' "$yaml_path")"
             architectures="$(yq -r -I=0 -o=csv '[.architectures[]."build-on"]' "$yaml_path" | tr ',' ' ')"
+          fi
         fi
 
         echo "architectures_list=$architectures_list" >> "$GITHUB_OUTPUT"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -111,7 +111,11 @@ runs:
         snapcraft_args=("--launchpad-accept-public-upload")
 
         # shellcheck disable=SC2193
-        if [[ "${{ steps.setup.outputs.new-remote-build }}" == "false" || "$SNAPCRAFT_REMOTE_BUILD_STRATEGY" == "force-fallback" ]]; then
+        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]]; then
+          # `core24` uses platforms syntax rather than `architectures`:
+          # https://snapcraft.io/docs/architectures
+          snapcraft_args+=("--platform $arch")
+        elif [[ "${{ steps.setup.outputs.new-remote-build }}" == "false" || "$SNAPCRAFT_REMOTE_BUILD_STRATEGY" == "force-fallback" ]]; then
           # Restrict arch definition to one only in snapcraft.yaml due to:
           # https://bugs.launchpad.net/snapcraft/+bug/1885150
           yq -i '.architectures |= [{"build-on": env(arch)}]' "$yaml_path"


### PR DESCRIPTION
core24 now uses the `platforms` keyword for specifying the build architecture for snaps rather than the `architectures` keyword. This pull request updates the get-architectures and release-to-candidate actions to support using the `platforms` top-level key to determine which arches to build the snap for.

Also, the remote-build command, when building core24 snaps, will use the `--platforms` flag rather than the `--build-for` flag.