### PR TITLE
feat: make bot name/email configurable

### DIFF
--- a/get-screenshots/README.md
+++ b/get-screenshots/README.md
@@ -29,6 +29,8 @@ jobs:
 
 | Key                      | Description                                                                                                                       | Required | Default                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | :------: | :---------------------------- |
+| `bot-email`              | The email address of the bot account used to commit screenshots.                                                                  |    N     | `snapforge.team@gmail.com`    |
+| `bot-name`               | The name of the bot account used to commit screenshots..                                                                          |    N     | `Snapcrafters Bot`            |
 | `issue-number`           | The issue number to post the screenshots to.                                                                                      |    Y     |                               |
 | `ci-repo`                | The repo to fetch tools/templates from. Only for debugging.                                                                       |    N     | `snapcrafters/ci`             |
 | `channel`                | The channel to create the call for testing for.                                                                                   |    N     | `latest/candidate`            |

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -6,6 +6,14 @@ branding:
   color: orange
 
 inputs:
+  bot-email:
+    description: "The email address of the bot account used to commit screenshots."
+    required: false
+    default: "snapforge.team@gmail.com"
+  bot-name:
+    description: "The name of the bot account used to commit screenshots."
+    required: false
+    default: "Snapcrafters Bot"
   issue-number:
     description: "The issue number to post the screenshots into"
     required: true
@@ -126,8 +134,8 @@ runs:
         cp -L "$HOME/ghvmctl-screenshots/screenshot-screen.png" "${file_prefix}-screen.png"
         cp -L "$HOME/ghvmctl-screenshots/screenshot-window.png" "${file_prefix}-window.png"
 
-        git config --global user.email "merlijn.sebrechts+snapcrafters-bot@gmail.com"
-        git config --global user.name "Snapcrafters Bot"
+        git config --global user.email "${{ inputs.bot-email }}"
+        git config --global user.name "${{ inputs.bot-name }}"
 
         git add -A .
         git commit -m "data: screenshots for snapcrafters/${snap_name}#${{ inputs.issue-number }}"

--- a/get-screenshots/action.yaml
+++ b/get-screenshots/action.yaml
@@ -138,7 +138,7 @@ runs:
         git config --global user.name "${{ inputs.bot-name }}"
 
         git add -A .
-        git commit -m "data: screenshots for snapcrafters/${snap_name}#${{ inputs.issue-number }}"
+        git commit -m "data: screenshots for ${github.repository_owner}/${snap_name}#${{ inputs.issue-number }}"
         git push origin main
 
         echo "screen=https://raw.githubusercontent.com/${{ inputs.screenshots-repo }}/main/${file_prefix}-screen.png" >> "$GITHUB_OUTPUT"

--- a/release-to-candidate/README.md
+++ b/release-to-candidate/README.md
@@ -24,16 +24,18 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                               | Required | Default            |
-| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :----------------- |
-| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`            |
-| `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate` |
-| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                    |
-| `multi-snap`             | Whether the repo contains the source for multiple snaps.                                  |    N     | `false`            |
+| Key                      | Description                                                                               | Required | Default                    |
+| ------------------------ | ----------------------------------------------------------------------------------------- | :------: | :------------------------- |
+| `architecture`           | The architecture for which to build the snap.                                             |    N     | `amd64`                    |
+| `bot-email`              | The email address of the bot account used to commit screenshots.                          |    N     | `snapforge.team@gmail.com` |
+| `bot-name`               | The name of the bot account used to commit screenshots..                                  |    N     | `Snapcrafters Bot`         |
+| `channel`                | The channel to release the snap to.                                                       |    N     | `latest/candidate`         |
+| `launchpad-token`        | A token with permissions to create Launchpad remote builds.                               |    Y     |                            |
+| `multi-snap`             | Whether the repo contains the source for multiple snaps.                                  |    N     | `false`                    |
 | `repo-token`             | A token with privileges to create and push tags to the repository.                        |    Y     |
-| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                    |
-| `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`    |
-| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                    |
+| `snapcraft-project-root` | The path to the Snapcraft YAML file.                                                      |    N     |                            |
+| `snapcraft-channel`      | The channel to install Snapcraft from.                                                    |    N     | `latest/stable`            |
+| `store-token`            | A token with permissions to upload and release to the specified channel in the Snap Store |    Y     |                            |
 
 ### Outputs
 

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -10,6 +10,14 @@ inputs:
     description: "The architecture to build the snap for"
     default: amd64
     required: false
+  bot-email:
+    description: "The email address of the bot account used to commit screenshots."
+    required: false
+    default: "snapforge.team@gmail.com"
+  bot-name:
+    description: "The name of the bot account used to commit screenshots."
+    required: false
+    default: "Snapcrafters Bot"
   channel:
     description: "The channel to publish the snap to"
     default: "latest/candidate"
@@ -70,8 +78,8 @@ runs:
           echo "new-remote-build=true" >> "$GITHUB_OUTPUT"
         fi
 
-        git config --global user.email "github-actions@github.com"
-        git config --global user.name "Github Actions"
+        git config --global user.email "${{ inputs.bot-email }}"
+        git config --global user.name "${{ inputs.bot-name }}"
 
     - name: Setup Launchpad credentials
       shell: bash
@@ -83,8 +91,8 @@ runs:
         echo "${{ inputs.launchpad-token }}" > ~/.local/share/snapcraft/provider/launchpad/credentials
         echo "${{ inputs.launchpad-token }}" > ~/.local/share/snapcraft/launchpad-credentials
 
-        git config --global user.email "github-actions@github.com"
-        git config --global user.name "Github Actions"
+        git config --global user.email "${{ inputs.bot-email }}"
+        git config --global user.name "${{ inputs.bot-name }}"
 
     - name: Find and parse snapcraft.yaml
       id: snapcraft-yaml
@@ -176,8 +184,8 @@ runs:
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         version: ${{ steps.snapcraft-yaml.outputs.version }}
       run: |
-        git config --global user.name 'Snapcrafters Bot'
-        git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
+        git config --global user.name "${{ inputs.bot-name }}"
+        git config --global user.email "${{ inputs.bot-email }}"
 
         revision="${{ steps.publish.outputs.revision }}"
 

--- a/sync-version/README.md
+++ b/sync-version/README.md
@@ -28,12 +28,14 @@ jobs:
 
 ### Inputs
 
-| Key                      | Description                                                                                                                       | Required |   Default   |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | -------- | :---------: |
-| `branch`                 | The branch on which modifications to snapcraft.yaml should be made.                                                               | N        | `candidate` |
-| `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. | N        |             |
-| `token`                  | A token with permissions to commit to the repository.                                                                             | Y        |             |
-| `update-script`          | A script that checks for version updates and updates `snapcraft.yaml` and other files if required.                                | Y        |             |
+| Key                      | Description                                                                                                                       | Required |          Default           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | -------- | :------------------------: |
+| `bot-email`              | The email address of the bot account used to commit screenshots.                                                                  | N        | `snapforge.team@gmail.com` |
+| `bot-name`               | The name of the bot account used to commit screenshots..                                                                          | N        |     `Snapcrafters Bot`     |
+| `branch`                 | The branch on which modifications to snapcraft.yaml should be made.                                                               | N        |        `candidate`         |
+| `snapcraft-project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. Do not include the trailing `/`. | N        |                            |
+| `token`                  | A token with permissions to commit to the repository.                                                                             | Y        |                            |
+| `update-script`          | A script that checks for version updates and updates `snapcraft.yaml` and other files if required.                                | Y        |                            |
 
 ### Outputs
 

--- a/sync-version/action.yaml
+++ b/sync-version/action.yaml
@@ -6,6 +6,14 @@ branding:
   color: orange
 
 inputs:
+  bot-email:
+    description: "The email address of the bot account used to commit screenshots."
+    required: false
+    default: "snapforge.team@gmail.com"
+  bot-name:
+    description: "The name of the bot account used to commit screenshots."
+    required: false
+    default: "Snapcrafters Bot"
   branch:
     description: "The branch on which modifications to snapcraft.yaml should be made."
     default: "candidate"
@@ -60,8 +68,8 @@ runs:
         if [[ ! "$old_version" == "$new_version" ]]; then
             version=$new_version
         fi
-        git config --global user.name 'Snapcrafters Bot'
-        git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
+        git config --global user.name "${{ inputs.bot-name }}"
+        git config --global user.email "${{ inputs.bot-email }}"
         if [[ -n "${version:-}" ]]; then
             git commit -am "chore: bump ${snap_name} to version ${version}"
         else


### PR DESCRIPTION
Fixes #39 

This should make the actions more reusable by people *other* than Snapcrafters.