### PR TITLE
feat(release-to-candidate): Support projects that doesn't specify the `version` property

### DIFF
--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -149,8 +149,8 @@ runs:
             # matching it via globbing
             snaps=("${name}_"*"_${arch}.snap")
             snap="${snaps[0]}"
-            snap_version_raw="${snap%_${arch}.snap}"
-            snap_version="${snap_version_raw#${name}_}"
+            snap_version_raw="${snap%"_${arch}.snap"}"
+            snap_version="${snap_version_raw#"${name}_"}"
         fi
 
         if [[ ! -e "${snap}" ]]; then

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -141,17 +141,27 @@ runs:
             cat snapcraft-${name}*${arch}*.txt || echo "Could not find build log"
         fi
 
-        if [[ ! -e "${name}_${version}_${arch}.snap" ]]; then
-            echo "Could not find ${name}_${version}_${arch}.snap"
+        snap_file=
+        if [[ "${version}" != "null" ]]; then
+            snap_file="${name}_${version}_${arch}.snap"
+        else
+            # snapcraft.yaml doesn't specify the _version_ property,
+            # matching it via globbing
+            snap_files=("${name}_"*"_${arch}.snap")
+            snap_file="${snap_files[0]}"
+        fi
+
+        if [[ ! -e "${snap_file}" ]]; then
+            echo "Could not find ${snap_file}"
             exit 1
         fi
 
         popd || exit
 
         # Write the manifest file which is used by later steps
-        echo "snap=${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+        echo "snap=${snap_file}" >> "$GITHUB_OUTPUT"
         if  [[ -n "$project_root" ]]; then
-            echo "snap=${project_root}/${name}_${version}_${arch}.snap" >> "$GITHUB_OUTPUT"
+            echo "snap=${project_root}/${snap_file}" >> "$GITHUB_OUTPUT"
         fi
         echo "name: ${name}" >> "manifest-${{ inputs.architecture }}.yaml"
         echo "architecture: ${arch}" >> "manifest-${{ inputs.architecture }}.yaml"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -149,6 +149,8 @@ runs:
             # matching it via globbing
             snaps=("${name}_"*"_${arch}.snap")
             snap="${snaps[0]}"
+            snap_version_raw="${snap%_${arch}.snap}"
+            snap_version="${snap_version_raw#${name}_}"
         fi
 
         if [[ ! -e "${snap}" ]]; then
@@ -162,6 +164,9 @@ runs:
         echo "snap=${snap}" >> "$GITHUB_OUTPUT"
         if  [[ -n "$project_root" ]]; then
             echo "snap=${project_root}/${snap}" >> "$GITHUB_OUTPUT"
+        fi
+        if  [[ "$version" == null ]]; then
+            echo "version=${snap_version}" >> "$GITHUB_OUTPUT"
         fi
         echo "name: ${name}" >> "manifest-${{ inputs.architecture }}.yaml"
         echo "architecture: ${arch}" >> "manifest-${{ inputs.architecture }}.yaml"
@@ -200,11 +205,16 @@ runs:
         multi_snap: ${{ inputs.multi-snap }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
         version: ${{ steps.snapcraft-yaml.outputs.version }}
+        build_version: ${{ steps.build.outputs.version }}
       run: |
         git config --global user.name "${{ inputs.bot-name }}"
         git config --global user.email "${{ inputs.bot-email }}"
 
         revision="${{ steps.publish.outputs.revision }}"
+
+        if [[ "${version}" == null ]]; then
+            version="${build_version}"
+        fi
 
         if [[ "${multi_snap}" == "true" ]]; then
           tag_name="${name}-${version}/rev${revision}/${{ inputs.architecture }}"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -141,27 +141,27 @@ runs:
             cat snapcraft-${name}*${arch}*.txt || echo "Could not find build log"
         fi
 
-        snap_file=
+        snap=
         if [[ "${version}" != "null" ]]; then
-            snap_file="${name}_${version}_${arch}.snap"
+            snap="${name}_${version}_${arch}.snap"
         else
             # snapcraft.yaml doesn't specify the _version_ property,
             # matching it via globbing
-            snap_files=("${name}_"*"_${arch}.snap")
-            snap_file="${snap_files[0]}"
+            snaps=("${name}_"*"_${arch}.snap")
+            snap="${snaps[0]}"
         fi
 
-        if [[ ! -e "${snap_file}" ]]; then
-            echo "Could not find ${snap_file}"
+        if [[ ! -e "${snap}" ]]; then
+            echo "Could not find ${snap}"
             exit 1
         fi
 
         popd || exit
 
         # Write the manifest file which is used by later steps
-        echo "snap=${snap_file}" >> "$GITHUB_OUTPUT"
+        echo "snap=${snap}" >> "$GITHUB_OUTPUT"
         if  [[ -n "$project_root" ]]; then
-            echo "snap=${project_root}/${snap_file}" >> "$GITHUB_OUTPUT"
+            echo "snap=${project_root}/${snap}" >> "$GITHUB_OUTPUT"
         fi
         echo "name: ${name}" >> "manifest-${{ inputs.architecture }}.yaml"
         echo "architecture: ${arch}" >> "manifest-${{ inputs.architecture }}.yaml"


### PR DESCRIPTION
It is possible that the Snapcraft project doesn't specify the `version` property in the snapcraft.yaml, instead of setting the snap version string via the `craftctl set version=_version_` mechanism.  In this case, the parse-snapcraft-yaml job will set the version variable to `null`, making the release-to-candidate job unable to detect the built snap due to a filename mismatch:

```
Created snap package tesseract_5.4.1+pkg-481c_amd64.snap
b0c0e58155889237f0b06b0fde00022b99079102e00be507be13ecd891ab44c13637957525631012869dafb04aeefc7794526af071f76523fbedfb26e581e01d  tesseract_5.4.1+pkg-481c_amd64.snap
Revoking proxy token...
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=lxd --series=jammy --arch=amd64 SNAPBUILD-2576220
Scanning for processes to kill in build SNAPBUILD-2576220
Could not find tesseract_null_amd64.snap
Error: Process completed with exit code 1.
```

This patch enhances the release-to-candidate job so that the built snap will still be matched via filename matching.

Although projects that don't specify the `version` property aren't really compliant with the Snapcrafters policy, supporting this use case allows external projects to reuse the snapcrafters/ci/release-to-candidate GitHub Action job without the need to fork the project.