### PR TITLE
feat: support uploading snap components

### DIFF
--- a/parse-snapcraft-yaml/README.md
+++ b/parse-snapcraft-yaml/README.md
@@ -43,6 +43,7 @@ jobs:
 | Key            | Description                                                                                      | Example                    |
 | -------------- | ------------------------------------------------------------------------------------------------ | -------------------------- |
 | `classic`      | Whether to snap is strictly confined                                                             | `false`                    |
+| `components`   | Comma-separated list of snap components and their versions (null if unversioned)                 | `comp-A\|1.0,comp-X\|null` |
 | `plugs-file`   | The location of a plugs declaration file to be used during review, if one was found              | `./plugs-declaration.json` |
 | `project-root` | The root of the snapcraft project, where the `snapcraft` command would usually be executed from. | `./ffmpeg-2204-sdk`        |
 | `slots-file`   | The location of a slots declaration file to be used during review, if one was found              | `./slots-declaration.json` |

--- a/parse-snapcraft-yaml/action.yaml
+++ b/parse-snapcraft-yaml/action.yaml
@@ -14,6 +14,9 @@ outputs:
   classic:
     description: "Whether to snap is strictly confined"
     value: ${{ steps.parse.outputs.classic }}
+  components:
+    description: "Comma-separated list of snap components and their versions (null if unversioned)"
+    value: ${{ steps.parse.outputs.components }}
   plugs-file:
     description: "The location of a plugs declaration file to be used during review, if one was found"
     value: ${{ steps.parse.outputs.plugs-file }}
@@ -91,3 +94,4 @@ runs:
         echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
         echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
         echo "version=$(yq -r '.version' "$yaml_path")" >> "$GITHUB_OUTPUT"
+        echo "components=$(yq -r '.components as $in | $in | keys | map("\(.)|\($in[.].version)") | join(",")' "$yaml_path")" >> "$GITHUB_OUTPUT"

--- a/parse-snapcraft-yaml/action.yaml
+++ b/parse-snapcraft-yaml/action.yaml
@@ -94,4 +94,5 @@ runs:
         echo "yaml-path=${yaml_path}" >> "$GITHUB_OUTPUT"
         echo "snap-name=$(yq -r '.name' "$yaml_path")" >> "$GITHUB_OUTPUT"
         echo "version=$(yq -r '.version' "$yaml_path")" >> "$GITHUB_OUTPUT"
+        # shellcheck disable=SC2016
         echo "components=$(yq -r '.components as $in | $in | keys | map("\(.)|\($in[.].version)") | join(",")' "$yaml_path")" >> "$GITHUB_OUTPUT"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -169,8 +169,21 @@ runs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-token }}
         SNAP_FILE: ${{ steps.build.outputs.snap }}
+        components: ${{ steps.snapcraft-yaml.outputs.components }}
+        name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
-        snapcraft_out="$(snapcraft push "$SNAP_FILE" --release="${{ inputs.channel }}")"
+        component_flags=""
+        for comp in ${components//,/ }
+        do
+            comp_name=$(echo "$comp" | cut -f1 -d"|")
+            comp_version=$(echo "$comp" | cut -f2 -d"|")
+            if [[ "${comp_version}" == "null" ]]; then
+                component_flags="${component_flags} --component ${comp_name}=${name}+${comp_name}.comp"
+            else
+                component_flags="${component_flags} --component ${comp_name}=${name}+${comp_name}_${comp_version}.comp"
+            fi
+        done
+        snapcraft_out="$(snapcraft upload "$SNAP_FILE" ${component_flags} --release="${{ inputs.channel }}")"
         revision="$(echo "$snapcraft_out" | grep -Po "Revision \K[^ ]+")"
         echo "revision=${revision}" >> "$GITHUB_OUTPUT"
         echo "revision: ${revision}" >> "manifest-${{ inputs.architecture }}.yaml"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -172,18 +172,18 @@ runs:
         components: ${{ steps.snapcraft-yaml.outputs.components }}
         name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
-        component_flags=""
+        component_flags=()
         for comp in ${components//,/ }
         do
             comp_name=$(echo "$comp" | cut -f1 -d"|")
             comp_version=$(echo "$comp" | cut -f2 -d"|")
             if [[ "${comp_version}" == "null" ]]; then
-                component_flags="${component_flags} --component ${comp_name}=${name}+${comp_name}.comp"
+                component_flags+=("--component" "${comp_name}=${name}+${comp_name}.comp")
             else
-                component_flags="${component_flags} --component ${comp_name}=${name}+${comp_name}_${comp_version}.comp"
+                component_flags+=("--component" "${comp_name}=${name}+${comp_name}_${comp_version}.comp")
             fi
         done
-        snapcraft_out="$(snapcraft upload "$SNAP_FILE" ${component_flags} --release="${{ inputs.channel }}")"
+        snapcraft_out="$(snapcraft upload "$SNAP_FILE" "${component_flags[@]}" --release="${{ inputs.channel }}")"
         revision="$(echo "$snapcraft_out" | grep -Po "Revision \K[^ ]+")"
         echo "revision=${revision}" >> "$GITHUB_OUTPUT"
         echo "revision: ${revision}" >> "manifest-${{ inputs.architecture }}.yaml"

--- a/release-to-candidate/action.yaml
+++ b/release-to-candidate/action.yaml
@@ -175,12 +175,13 @@ runs:
         component_flags=()
         for comp in ${components//,/ }
         do
-            comp_name=$(echo "$comp" | cut -f1 -d"|")
-            comp_version=$(echo "$comp" | cut -f2 -d"|")
+            comp_name="$(echo "$comp" | cut -f1 -d"|")"
+            comp_version="$(echo "$comp" | cut -f2 -d"|")"
+            component_flags+=("--component")
             if [[ "${comp_version}" == "null" ]]; then
-                component_flags+=("--component" "${comp_name}=${name}+${comp_name}.comp")
+                component_flags+=("${comp_name}=${name}+${comp_name}.comp")
             else
-                component_flags+=("--component" "${comp_name}=${name}+${comp_name}_${comp_version}.comp")
+                component_flags+=("${comp_name}=${name}+${comp_name}_${comp_version}.comp")
             fi
         done
         snapcraft_out="$(snapcraft upload "$SNAP_FILE" "${component_flags[@]}" --release="${{ inputs.channel }}")"


### PR DESCRIPTION
This adds support for automatically detecting any [snap components](https://documentation.ubuntu.com/snapcraft/8.6.2/howto/components/) defined in a snap's `snapcraft.yaml`, and if found, uploading those components along with the snap to the store.

Side note: I updated from `snap push` to `snap upload` as the latter is now preferred and the former is being deprecated.

In parallel, I have asked the Snap Store team to grant permissions for snap components to be uploaded if published under `snapcrafters`.

Note I have tested the commands locally but have NOT tested from a GitHub action pointed at my fork. I can do so for testing a snap WITHOUT components, but do not have permissions in the store needed to test uploads for a snap with components.
