### PR TITLE
fix(run-tests): allow running on multiple architectures

### DIFF
--- a/run-tests/action.yaml
+++ b/run-tests/action.yaml
@@ -46,8 +46,8 @@ runs:
         snap_name: ${{ steps.snapcraft-yaml.outputs.snap-name }}
       run: |
         # If we got a manifest file then parse the revision from it
-        if ls manifest-amd64.yaml &>/dev/null; then
-          arch="$(dpkg --print-architecture)"
+        arch="$(dpkg --print-architecture)"
+        if ls "manifest-${arch}.yaml" &>/dev/null; then
           rev="$(yq -r '.revision' "manifest-${arch}.yaml")"
           echo "Installing snap revision '${rev}' from build manifest"
           sudo snap install "${snap_name}" --revision "${rev}"

--- a/run-tests/action.yaml
+++ b/run-tests/action.yaml
@@ -48,7 +48,7 @@ runs:
         # If we got a manifest file then parse the revision from it
         if ls manifest-amd64.yaml &>/dev/null; then
           arch="$(dpkg --print-architecture)"
-          rev="$(yq -r '.revision' manifest-$arch.yaml)"
+          rev="$(yq -r '.revision' "manifest-${arch}.yaml")"
           echo "Installing snap revision '${rev}' from build manifest"
           sudo snap install "${snap_name}" --revision "${rev}"
         else

--- a/run-tests/action.yaml
+++ b/run-tests/action.yaml
@@ -47,7 +47,8 @@ runs:
       run: |
         # If we got a manifest file then parse the revision from it
         if ls manifest-amd64.yaml &>/dev/null; then
-          rev="$(yq -r '.revision' manifest-amd64.yaml)"
+          arch="$(dpkg --print-architecture)"
+          rev="$(yq -r '.revision' manifest-$arch.yaml)"
           echo "Installing snap revision '${rev}' from build manifest"
           sudo snap install "${snap_name}" --revision "${rev}"
         else


### PR DESCRIPTION
This allows running the tests on multiple architectures, so we can use GitHub's ARM runners to test on ARM.

Fixes [this behaviour](https://github.com/snapcrafters/ruff/actions/runs/17565385552/job/49904778894).